### PR TITLE
#184:fix a wrong word

### DIFF
--- a/docs/zh-cn/dev/design.md
+++ b/docs/zh-cn/dev/design.md
@@ -44,7 +44,7 @@
 * **dubbo-cluster 集群模块**：将多个服务提供方伪装为一个提供方，包括：负载均衡, 容错，路由等，集群的地址列表可以是静态配置的，也可以是由注册中心下发。
 * **dubbo-registry 注册中心模块**：基于注册中心下发地址的集群方式，以及对各种注册中心的抽象。
 * **dubbo-monitor 监控模块**：统计服务调用次数，调用时间的，调用链跟踪的服务。
-* **dubbo-config 配置模块**：是 Dubbo 对外的 API，用户通过 Config 使用D ubbo，隐藏 Dubbo 所有细节。
+* **dubbo-config 配置模块**：是 Dubbo 对外的 API，用户通过 Config 使用Dubbo，隐藏 Dubbo 所有细节。
 * **dubbo-container 容器模块**：是一个 Standlone 的容器，以简单的 Main 加载 Spring 启动，因为服务通常不需要 Tomcat/JBoss 等 Web 容器的特性，没必要用 Web 容器去加载服务。
 
 整体上按照分层结构进行分包，与分层的不同点在于：


### PR DESCRIPTION
## What is the purpose of the change

the page "文档-框架设计" has a wrong word,the word "Dubbo" is spelled as "D ubbo"，as shown the picture below:
![image](https://user-images.githubusercontent.com/34837528/48830854-8703cb80-edb0-11e8-983b-c86c054b6a98.png)

## Brief changelog
correct it as "Dubbo",as shown the picture below:
![image](https://user-images.githubusercontent.com/34837528/48831514-f1693b80-edb1-11e8-9484-df4a4e88b68c.png)

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo-website/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Test your code locally by running `docsite start`, and make sure it works as expected.
- [ ] Make sure no files under build directory is added.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
