### PR TITLE
About the parameter unicast of the multicast description is not accurate

### DIFF
--- a/docs/zh-cn/user/references/registry/multicast.md
+++ b/docs/zh-cn/user/references/registry/multicast.md
@@ -23,7 +23,7 @@ Multicast 注册中心不需要启动任何中心节点，只要广播地址一�
 <dubbo:registry protocol="multicast" address="224.5.6.7:1234" />
 ```
 
-为了减少广播量，Dubbo 缺省使用单播发送提供者地址信息给消费者，如果一个机器上同时启了多个消费者进程，消费者需声明 `unicast=false`，否则只会有一个消费者能收到消息：
+为了减少广播量，Dubbo 缺省使用单播发送提供者地址信息给消费者，如果一个机器上同时启了多个消费者进程，消费者需声明 `unicast=false`，否则只会有一个消费者能收到消息;当服务者和消费者运行在同一台机器上，消费者同样需要声明`unicast=false`，否则消费者无法收到消息，导致No provider available for the service异常：
 
 ```xml
 <dubbo:registry address="multicast://224.5.6.7:1234?unicast=false" />


### PR DESCRIPTION
When running dubbo-demo-annotation, the provider and consumer are on one machine at the same time, the consumer may have an exception of No provider available for the service, then you also need the consumer to declare unicast=false, and in this case Only one consumer

## What is the purpose of the change

Supplementary description of unicast usage scenarios

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo-website/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Test your code locally by running `docsite start`, and make sure it works as expected.
- [ ] Make sure no files under build directory is added.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
