### PR TITLE
修正一些文档中的错误

### DIFF
--- a/docs/zh-cn/user/recommend.md
+++ b/docs/zh-cn/user/recommend.md
@@ -19,10 +19,10 @@ Provider 端尽量多配置 Consumer 端的属性，让 Provider 的实现者一
 
 ```xml
 <dubbo:service interface="com.alibaba.hello.api.HelloService" version="1.0.0" ref="helloService"
-    timeout="300" retry="2" loadbalance="random" actives="0" />
+    timeout="300" retries="2" loadbalance="random" actives="0" />
  
 <dubbo:service interface="com.alibaba.hello.api.WorldService" version="1.0.0" ref="helloService"
-    timeout="300" retry="2" loadbalance="random" actives="0" >
+    timeout="300" retries="2" loadbalance="random" actives="0" >
     <dubbo:method name="findAllPerson" timeout="10000" retries="9" loadbalance="leastactive" actives="5" />
 <dubbo:service/>
 ```
@@ -123,7 +123,7 @@ Dubbo 中所有的配置项都可以配置在 Spring 配置文件中，并且可
     ```
     
 2. 注册中心地址 `dubbo.registry.address`
-    
+   
     ```xml
     <dubbo:registry address="11.22.33.44:9090" >
     ```

--- a/docs/zh-cn/user/references/xml/dubbo-service.md
+++ b/docs/zh-cn/user/references/xml/dubbo-service.md
@@ -20,7 +20,7 @@
 | mock | mock | class/boolean | 可选 | false | 服务治理 | 设为true，表示使用缺省Mock类名，即：接口名 + Mock后缀，服务接口调用失败Mock实现类，该Mock类必须有一个无参构造函数，与Local的区别在于，Local总是被执行，而Mock只在出现非业务异常(比如超时，网络异常等)时执行，Local在远程调用之前执行，Mock在远程调用后执行。 | 2.0.0以上版本 |
 | token | token | string/boolean | 可选 | false | 服务治理 | 令牌验证，为空表示不开启，如果为true，表示随机生成动态令牌，否则使用静态令牌，令牌的作用是防止消费者绕过注册中心直接访问，保证注册中心的授权功能有效，如果使用点对点调用，需关闭令牌功能 | 2.0.0以上版本 |
 | registry | | string | 可选 | 缺省向所有registry注册 | 配置关联 | 向指定注册中心注册，在多个注册中心时使用，值为&lt;dubbo:registry&gt;的id属性，多个注册中心ID用逗号分隔，如果不想将该服务注册到任何registry，可将值设为N/A | 2.0.0以上版本 |
-| provider | | string | 可选 | 缺使用第一个provider配置 | 配置关联 | 指定provider，值为&lt;dubbo:provider&gt;的id属性 | 2.0.0以上版本 |
+| provider | | string | 可选 | 缺省使用第一个provider配置 | 配置关联 | 指定provider，值为&lt;dubbo:provider&gt;的id属性 | 2.0.0以上版本 |
 | deprecated | deprecated | boolean | 可选 | false | 服务治理 | 服务是否过时，如果设为true，消费方引用时将打印服务过时警告error日志 | 2.0.5以上版本 |
 | dynamic | dynamic | boolean | 可选 | true | 服务治理 | 服务是否动态注册，如果设为false，注册后将显示后disable状态，需人工启用，并且服务提供者停止时，也不会自动取消册，需人工禁用。 | 2.0.5以上版本 |
 | accesslog | accesslog | string/boolean | 可选 | false | 服务治理 | 设为true，将向logger中输出访问日志，也可填写访问日志文件路径，直接把访问日志输出到指定文件 | 2.0.5以上版本 |

--- a/docs/zh-cn/user/versions/version-270.md
+++ b/docs/zh-cn/user/versions/version-270.md
@@ -92,7 +92,6 @@ dubbo.metadataReport.address=redis://127.0.0.1:6379
 
 
 <h4 id="1.2">使用外部化配置</h4>
-
 需要在项目启动前，使用[最新版本Dubbo-OPS](https://github.com/apache/dubbo-ops)完成外部化配置迁移，理论上配置中心支持所有本地dubbo.properties所支持的配置项。
 
 以XML开发形式为例，假设我们本地有如下配置：
@@ -217,7 +216,6 @@ dubbo.protocol.port=20880
 
 
 <h4 id="1.1">包名改造</h4>
-
 1. Maven坐标
 
 **groupId 由 `com.alibaba` 改为 `org.apache.dubbo`**
@@ -251,8 +249,8 @@ Maven坐标升级比较直观，只需要修改相应的pom文件就可以了；
 | ServiceConfig     | Service配置采集和暴露编程接口 |
 | ApplicationConfig | Application配置采集API        |
 | RegistryConfig    | 注册中心配置采集API           |
-| ConsumerConfig    | 提供端默认配置采集API         |
-| ProviderConfig    | 消费端默认配置采集API         |
+| ConsumerConfig    | 消费端默认配置采集API         |
+| ProviderConfig    | 提供端默认配置采集API         |
 | ProtocolConfig    | RPC协议配置采集API            |
 | ArcumentConfig    | 服务参数级配置采集API         |
 | MethodConfig      | 服务方法级配置采集API         |


### PR DESCRIPTION
## 修正中文文档中的若干拼写和翻译错误

1. version-28.md 中对 ConsumerConfig 和 ProviderConfig 翻译错误的问题。
2. dubbo-service.md 中 文字拼写 “缺省” 漏掉“省”的问题。
3. recommend.md 中 dubbo:service 配置retries 写成 retry 的问题。