### PR TITLE
update download page after 2.6.7 released.

### DIFF
--- a/blog/en-us/download.md
+++ b/blog/en-us/download.md
@@ -59,7 +59,7 @@ you can follow these [procedures](https://www.apache.org/info/verification) and 
 [asc](https://archive.apache.org/dist/incubator/dubbo/2.7.0/apache-dubbo-incubating-2.7.0-bin-release.zip.asc) |
 [sha512](https://archive.apache.org/dist/incubator/dubbo/2.7.0/apache-dubbo-incubating-2.7.0-bin-release.zip.sha512)
 
-### 2.6.7 (2019-07-12)
+### 2.6.7 (2019-07-15)
 
 * [source](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-source-release.zip) |
 [asc](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-source-release.zip.asc) |

--- a/blog/en-us/download.md
+++ b/blog/en-us/download.md
@@ -59,6 +59,15 @@ you can follow these [procedures](https://www.apache.org/info/verification) and 
 [asc](https://archive.apache.org/dist/incubator/dubbo/2.7.0/apache-dubbo-incubating-2.7.0-bin-release.zip.asc) |
 [sha512](https://archive.apache.org/dist/incubator/dubbo/2.7.0/apache-dubbo-incubating-2.7.0-bin-release.zip.sha512)
 
+### 2.6.7 (2019-07-12)
+
+* [source](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-source-release.zip) |
+[asc](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-source-release.zip.asc) |
+[sha512](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-source-release.zip.sha512)
+* [binary](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-bin-release.zip) |
+[asc](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-bin-release.zip.asc) |
+[sha512](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-bin-release.zip.sha512)
+
 ### 2.6.6 (2019-03-07)
 
 * [source](https://www.apache.org/dyn/closer.cgi?path=incubator/dubbo/2.6.6/apache-dubbo-incubating-2.6.6-source-release.zip) |

--- a/blog/zh-cn/download.md
+++ b/blog/zh-cn/download.md
@@ -59,7 +59,7 @@ description: 本文将向你介绍如何点击了解各版本详情和升级注�
 [asc](https://archive.apache.org/dist/incubator/dubbo/2.7.0/apache-dubbo-incubating-2.7.0-bin-release.zip.asc) |
 [sha512](https://archive.apache.org/dist/incubator/dubbo/2.7.0/apache-dubbo-incubating-2.7.0-bin-release.zip.sha512)
 
-### 2.6.7 (2019-07-12)
+### 2.6.7 (2019-07-15)
 
 * [source](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-source-release.zip) |
 [asc](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-source-release.zip.asc) |

--- a/blog/zh-cn/download.md
+++ b/blog/zh-cn/download.md
@@ -59,6 +59,14 @@ description: 本文将向你介绍如何点击了解各版本详情和升级注�
 [asc](https://archive.apache.org/dist/incubator/dubbo/2.7.0/apache-dubbo-incubating-2.7.0-bin-release.zip.asc) |
 [sha512](https://archive.apache.org/dist/incubator/dubbo/2.7.0/apache-dubbo-incubating-2.7.0-bin-release.zip.sha512)
 
+### 2.6.7 (2019-07-12)
+
+* [source](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-source-release.zip) |
+[asc](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-source-release.zip.asc) |
+[sha512](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-source-release.zip.sha512)
+* [binary](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-bin-release.zip) |
+[asc](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-bin-release.zip.asc) |
+[sha512](https://www.apache.org/dist/dubbo/2.6.7/apache-dubbo-2.6.7-bin-release.zip.sha512)
 
 ### 2.6.6 (2019-03-07)
 


### PR DESCRIPTION
## What is the purpose of the change

update download page after 2.6.7 released

## Brief changelog

1. blog/en-us/download.md
2. blog/zh-cn/download.md
