### PR TITLE
fix (en_us) dubbo-zk.md - spelling mistakes

### DIFF
--- a/blog/en-us/dubbo-zk.md
+++ b/blog/en-us/dubbo-zk.md
@@ -139,7 +139,7 @@ Zookeeper is used for service registration discovery and configuration managemen
 
 ![dubbo-in-zk](../../img/blog/dubbo-in-zk.jpg)
 
-First, all data related to Dubbo is organized under the root node of `/duboo`.
+First, all data related to Dubbo is organized under the root node of `/dubbo`.
 
 The secondary directory is the service name like `com.foo.BarService`.
 


### PR DESCRIPTION
## What is the purpose of the change

fix (en_us) dubbo-zk.md - spelling mistakes

## Brief changelog

1.  blog/en-us/dubbo-zk.md