### PR TITLE
fix (en_us) benchmark-tool.md - spelling mistakes

### DIFF
--- a/docs/en-us/user/benchmark-tool.md
+++ b/docs/en-us/user/benchmark-tool.md
@@ -26,7 +26,7 @@ Read ReadMe.txt (the contents are as follows, in the compressed package.)
 
 * Put the demo.benchmark.jar and service API jar into directory dubbo.benchmark/lib
 
-* Configuring duubo.properties
+* Configuring dubbo.properties
 
 * Run run.bat(windows) or run.sh(linux)
 


### PR DESCRIPTION
## What is the purpose of the change

fix (en_us) benchmark-tool.md - spelling mistakes

## Brief changelog

1. docs/en-us/user/benchmark-tool.md