### PR TITLE
Fix (en-us)download.md 2.7.2 Link failure

### DIFF
--- a/blog/en-us/download.md
+++ b/blog/en-us/download.md
@@ -36,9 +36,9 @@ you can follow these [procedures](https://www.apache.org/info/verification) and 
 
 ### 2.7.2 (2019-06-06)
 
-* [source](https://archive.apache.org/dist/incubator/dubbo/2.7.2/apache-dubbo-incubating-2.7.2-src.zip) |
-[asc](https://archive.apache.org/dist/incubator/dubbo/2.7.2/apache-dubbo-incubating-2.7.2-src.zip.asc) |
-[sha512](https://archive.apache.org/dist/incubator/dubbo/2.7.2/apache-dubbo-incubating-2.7.2-src.zip.sha512)
+* [source](https://archive.apache.org/dist/dubbo/2.7.2/apache-dubbo-2.7.2-src.zip) |
+[asc](https://archive.apache.org/dist/dubbo/2.7.2/apache-dubbo-2.7.2-src.zip.asc) |
+[sha512](https://archive.apache.org/dist/dubbo/2.7.2/apache-dubbo-2.7.2-src.zip.sha512)
 
 ### 2.7.1 (2019-03-26)
 


### PR DESCRIPTION

## What is the purpose of the change

Fix (en-us)download.md 2.7.2 Link failure

## Brief changelog

1.blog/en-us/download.md
