### PR TITLE
fix: spelling mistake

### DIFF
--- a/docs/en-us/admin/install/redis.md
+++ b/docs/en-us/admin/install/redis.md
@@ -4,7 +4,7 @@
 
 Redis [^1] introductions, please refer to: [Redis application center manual](http://dubbo.apache.org/books/dubbo-user-book-en/references/registry/redis.html)。
 
-you need an origin Redis server only, and change the value from `dubbo.registry.addrss` to `redis://127.0.0.1:6379` in `conf/dubbo.properties` of [quick start](http://dubbo.apache.org/books/dubbo-user-book-en/quick-start.html)
+you need an origin Redis server only, and change the value from `dubbo.registry.address` to `redis://127.0.0.1:6379` in `conf/dubbo.properties` of [quick start](http://dubbo.apache.org/books/dubbo-user-book-en/quick-start.html)
 
 Redis configuration center cluster [^2] write multiple server in client side and read from a single server.
 

--- a/docs/en-us/dev/implementation.md
+++ b/docs/en-us/dev/implementation.md
@@ -110,7 +110,7 @@ public class DemoClientAction {
     }
  
     public void start() {
-        String hello = demoService.sayHello("world" + i);
+        String hello = demoService.sayHello("world");
     }
 }
 ```

--- a/docs/en-us/user/references/registry/redis.md
+++ b/docs/en-us/user/references/registry/redis.md
@@ -65,7 +65,7 @@ A home-brewed service registry server is used in Alibaba instead of redis server
 ## Installation
 
 
-Pls. refer to [redis install manual](http://dubbo.apache.org/en-us/docs/admin/install/redis.html) for how to install a redis based registry server. To set it up, specify `dubbo.registry.addrss` to `redis://127.0.0.1:6379` in `conf/dubbo.properties` for both provider and consumer (you can refer to [quick start](../../quick-start.md)) after install a redis server.
+Pls. refer to [redis install manual](http://dubbo.apache.org/en-us/docs/admin/install/redis.html) for how to install a redis based registry server. To set it up, specify `dubbo.registry.address` to `redis://127.0.0.1:6379` in `conf/dubbo.properties` for both provider and consumer (you can refer to [quick start](../../quick-start.md)) after install a redis server.
 
 
 [^1]: [Redis](http://redis.io) is a high performance KV cache server

--- a/docs/zh-cn/admin/install/redis.md
+++ b/docs/zh-cn/admin/install/redis.md
@@ -4,7 +4,7 @@
 
 Redis [^1] 使用方式参见: [Redis 注册中心参考手册](http://dubbo.apache.org/books/dubbo-user-book/references/registry/redis.html)。
 
-只需搭一个原生的 Redis 服务器，并将[快速启动](http://dubbo.apache.org/books/dubbo-user-book/quick-start.html)中 Provider 和 Consumer 里的 `conf/dubbo.properties` 中的 `dubbo.registry.addrss` 的值改为 `redis://127.0.0.1:6379` 即可使用。
+只需搭一个原生的 Redis 服务器，并将[快速启动](http://dubbo.apache.org/books/dubbo-user-book/quick-start.html)中 Provider 和 Consumer 里的 `conf/dubbo.properties` 中的 `dubbo.registry.address` 的值改为 `redis://127.0.0.1:6379` 即可使用。
 
 Redis 注册中心集群 [^2] 采用在客户端同时写入多个服务器，读取单个服务器的策略实现。
 

--- a/docs/zh-cn/dev/implementation.md
+++ b/docs/zh-cn/dev/implementation.md
@@ -110,7 +110,7 @@ public class DemoClientAction {
     }
  
     public void start() {
-        String hello = demoService.sayHello("world" + i);
+        String hello = demoService.sayHello("world");
     }
 }
 ```

--- a/docs/zh-cn/user/references/registry/redis.md
+++ b/docs/zh-cn/user/references/registry/redis.md
@@ -68,7 +68,7 @@
 ## 安装
 
 
-安装方式参见: [Redis安装手册]( ../../../admin/install/redis.md)，只需搭一个原生的 Redis 服务器，并将 [Quick Start](../../preface/usage.md) 中 Provider 和 Consumer 里的 `conf/dubbo.properties` 中的 `dubbo.registry.addrss` 的值改为 `redis://127.0.0.1:6379` 即可使用。
+安装方式参见: [Redis安装手册]( ../../../admin/install/redis.md)，只需搭一个原生的 Redis 服务器，并将 [Quick Start](../../preface/usage.md) 中 Provider 和 Consumer 里的 `conf/dubbo.properties` 中的 `dubbo.registry.address` 的值改为 `redis://127.0.0.1:6379` 即可使用。
 
 
 [^1]: [Redis](http://redis.io) 是一个高效的 KV 存储服务器

--- a/docs/zh-cn/user/references/registry/zookeeper.md
+++ b/docs/zh-cn/user/references/registry/zookeeper.md
@@ -1,6 +1,6 @@
 # zookeeper 注册中心
 
-[Zookeeper](http://zookeeper.apache.org) 是 Apacahe Hadoop 的子项目，是一个树型的目录服务，支持变更推送，适合作为 Dubbo 服务的注册中心，工业强度较高，可用于生产环境，并推荐使用 [^1]。
+[Zookeeper](http://zookeeper.apache.org) 是 Apache Hadoop 的子项目，是一个树型的目录服务，支持变更推送，适合作为 Dubbo 服务的注册中心，工业强度较高，可用于生产环境，并推荐使用 [^1]。
 
 ![/user-guide/images/zookeeper.jpg](../../sources/images/zookeeper.jpg)
 


### PR DESCRIPTION
## What is the purpose of the change

Fix spelling mistake

## Brief changelog

(#573) Remove field  "i" which is not initialization and definition
(#564) Correct spelling mistake in the zookeeper.md file
(#506) Correct spelling mistake of `dubbo.registry.addrss`
