### PR TITLE
Fix samples validation link error

### DIFF
--- a/docs/en-us/user/demos/parameter-validation.md
+++ b/docs/en-us/user/demos/parameter-validation.md
@@ -179,5 +179,5 @@ public class ValidationConsumer {
 }
 ```
 
-[^1]: Support since `2.1.0` version. If you want to know how to use it, refer to  [Sample code in dubbo project] (https://github.com/apache/dubbo-samples/tree/master/dubbo-samples-validation)
+[^1]: Support since `2.1.0` version. If you want to know how to use it, refer to  [Sample code in dubbo project] (https://github.com/apache/dubbo-samples/tree/master/java/dubbo-samples-validation)
 [^2]: The validation method is extensible, refer to [Developer Extension](http://dubbo.apache.org/zh-cn/docs/dev/impls/validation.html) in the developer's manual.

--- a/docs/zh-cn/user/demos/parameter-validation.md
+++ b/docs/zh-cn/user/demos/parameter-validation.md
@@ -179,5 +179,5 @@ public class ValidationConsumer {
 }
 ```
 
-[^1]: 自 `2.1.0` 版本开始支持, 如何使用可以参考 [dubbo 项目中的示例代码](https://github.com/apache/dubbo-samples/tree/master/dubbo-samples-validation)
+[^1]: 自 `2.1.0` 版本开始支持, 如何使用可以参考 [dubbo 项目中的示例代码](https://github.com/apache/dubbo-samples/tree/master/java/dubbo-samples-validation)
 [^2]: 验证方式可扩展，扩展方式参见开发者手册中的[验证扩展](http://dubbo.apache.org/zh-cn/docs/dev/impls/validation.html)


### PR DESCRIPTION
What is the purpose of the change
文档页脚的Dubbo项目中的示例代码链接错误
Brief changelog
from：https://github.com/apache/dubbo-samples/tree/master/dubbo-samples-validation
to: https://github.com/apache/dubbo-samples/tree/master/java/dubbo-samples-validation