### PR TITLE
fix some wrong website address

### DIFF
--- a/docs/zh-cn/user/configuration/annotation.md
+++ b/docs/zh-cn/user/configuration/annotation.md
@@ -7,7 +7,7 @@ description: 注解配置
 # 注解配置
 
 需要 `2.6.3` 及以上版本支持
-点此查看[完整示例](https://github.com/apache/dubbo-samples/tree/master/dubbo-samples-annotation)
+点此查看[完整示例](https://github.com/apache/dubbo-samples/tree/master/java/dubbo-samples-annotation)
 
 ## 服务提供方
 

--- a/docs/zh-cn/user/configuration/xml.md
+++ b/docs/zh-cn/user/configuration/xml.md
@@ -2,7 +2,7 @@
 
 有关 XML 的详细配置项，请参见：[配置参考手册](../references/xml/introduction.md)。如果不想使用 Spring 配置，而希望通过 API 的方式进行调用，请参见：[API配置](./api.md)。想知道如何使用配置，请参见：[快速启动](../quick-start.md)。
 
-请在此查看文档描述的[完整示例](https://github.com/apache/dubbo-samples/tree/master/dubbo-samples-basic)
+请在此查看文档描述的[完整示例](https://github.com/apache/dubbo-samples/tree/master/java/dubbo-samples-basic)
 
 ## provider.xml 示例
 


### PR DESCRIPTION
## Fix some wrong website address

Some website address is wrong, because there is a new parent directory in [dubbo-samples](https://github.com/apache/dubbo-samples) project：java & golang. It causes a 404 error.

For Example：http://dubbo.apache.org/zh-cn/docs/user/configuration/xml.html

![image](https://user-images.githubusercontent.com/48505670/95813715-13c02580-0d4b-11eb-88c9-63a9f8310aa2.png)

Maybe there are more similar errors for the same reason, you group better check it.