### PR TITLE
fix sample code for MulticastRegistry

### DIFF
--- a/content/en/docs/v2.7/user/references/registry/multicast.md
+++ b/content/en/docs/v2.7/user/references/registry/multicast.md
@@ -33,13 +33,15 @@ Or
 In order to avoid multicast as much as possible, dubbo uses unicast for address information from service provider to service consumer, if there are multiple consumer processes on one single machine, consumers need to set `unicast=false`, otherwise only one consumer can be able to receive the address info:
 
 ```xml
-<dubbo:registry address="multicast://224.5.6.7:1234?unicast=false" />
+<dubbo:application name="demo-consumer">
+    <dubbo:parameter key="unicast" value="false" />
+</dubbo:application>
 ```
 
 Or
 
 ```xml
-<dubbo:registry protocol="multicast" address="224.5.6.7:1234">
+<dubbo:consumer>
     <dubbo:parameter key="unicast" value="false" />
-</dubbo:registry>
+</dubbo:consumer>
 ```

--- a/content/zh/docs/v2.7/user/references/registry/multicast.md
+++ b/content/zh/docs/v2.7/user/references/registry/multicast.md
@@ -29,7 +29,7 @@ Multicast 注册中心不需要启动任何中心节点，只要广播地址一�
 <dubbo:registry protocol="multicast" address="224.5.6.7:1234" />
 ```
 
-为了减少广播量，Dubbo 缺省使用单播发送提供者地址信息给消费者，如果一个机器上同时启了多个消费者进程，消费者需声明 `unicast=false`，否则只会有一个消费者能收到消息;当服务者和消费者运行在同一台机器上，消费者同样需要声明`unicast=false`，否则消费者无法收到消息，导致No provider available for the service异常：
+为了减少广播量，Dubbo 缺省使用单播发送提供者地址信息给消费者，如果一个机器上同时启了多个消费者进程，消费者需声明 `unicast=false`，否则只会有一个消费者能收到消息; 当服务者和消费者运行在同一台机器上，消费者同样需要声明`unicast=false`，否则消费者无法收到消息，导致No provider available for the service异常：
 
 ```xml
 <dubbo:application name="demo-consumer">

--- a/content/zh/docs/v2.7/user/references/registry/multicast.md
+++ b/content/zh/docs/v2.7/user/references/registry/multicast.md
@@ -32,13 +32,15 @@ Multicast 注册中心不需要启动任何中心节点，只要广播地址一�
 为了减少广播量，Dubbo 缺省使用单播发送提供者地址信息给消费者，如果一个机器上同时启了多个消费者进程，消费者需声明 `unicast=false`，否则只会有一个消费者能收到消息;当服务者和消费者运行在同一台机器上，消费者同样需要声明`unicast=false`，否则消费者无法收到消息，导致No provider available for the service异常：
 
 ```xml
-<dubbo:registry address="multicast://224.5.6.7:1234?unicast=false" />
+<dubbo:application name="demo-consumer">
+    <dubbo:parameter key="unicast" value="false" />
+</dubbo:application>
 ```
 
 或
 
 ```xml
-<dubbo:registry protocol="multicast" address="224.5.6.7:1234">
+<dubbo:consumer>
     <dubbo:parameter key="unicast" value="false" />
-</dubbo:registry>
+</dubbo:consumer>
 ```


### PR DESCRIPTION
[Parameter `unicast` is invalid with MulticastRegistry #4136](https://github.com/apache/dubbo/issues/4136)
[能不能把官网的文档更新一下啊，这是坑啊！ #5263](https://github.com/apache/dubbo/issues/5263)