### PR TITLE
Add broadcast.fail.percent usage example in broadcast cluster.

### DIFF
--- a/content/en/docs/v2.7/user/examples/fault-tolerent-strategy.md
+++ b/content/en/docs/v2.7/user/examples/fault-tolerent-strategy.md
@@ -66,6 +66,18 @@ Multiple servers are invoked in parallel, returning as soon as one succeeds. Usu
 
 Calling all providers broadcast, one by one call, any error is reported (`2.1.0+`). It is usually used to notify all providers to update local resource information such as caches or logs.
 
+Now in the broadcast call, the proportion of node call failures can be configured through broadcast.fail.percent. When this proportion is reached, BroadcastClusterInvoker will no longer call other nodes and directly throw an exception. The value of broadcast.fail.percent is in the range of 0-100. By default, an exception will be thrown when all calls fail.
+broadcast.fail.percent only controls whether to continue to call other nodes after failure, and does not change the result (any one will report an error). broadcast.fail.percent parameters
+Effective in dubbo2.7.10 and above.
+
+Broadcast Cluster configuration broadcast.fail.percent.
+
+broadcast.fail.percent=20 means that when 20% of the nodes fail to call, an exception will be thrown and no other nodes will be called.
+
+```text
+@reference(cluster = "broadcast", parameters = {"broadcast.fail.percent", "20"})
+```
+
 ## Cluster mode configuration
 
 Follow the example below to configure cluster mode on service providers and consumers

--- a/content/zh/docs/v2.7/user/examples/fault-tolerent-strategy.md
+++ b/content/zh/docs/v2.7/user/examples/fault-tolerent-strategy.md
@@ -70,6 +70,19 @@ description: "集群调用失败时，Dubbo 提供的容错方案"
 
 广播调用所有提供者，逐个调用，任意一台报错则报错。通常用于通知所有提供者更新缓存或日志等本地资源信息。
 
+现在广播调用中，可以通过 broadcast.fail.percent 配置节点调用失败的比例，当达到这个比例后，BroadcastClusterInvoker
+将不再调用其他节点，直接抛出异常. broadcast.fail.percent 取值在 0～100 范围内。默认情况下当全部调用失败后，才会抛出异常。
+broadcast.fail.percent 只是控制的当失败后是否继续调用其他节点，并不改变结果(任意一台报错则报错)。
+
+Broadcast Cluster 配置 broadcast.fail.percent.
+
+broadcast.fail.percent=20 代表了当 20% 的节点调用失败就抛出异常，不再调用其他节点。
+
+```text
+@reference(cluster = "broadcast", parameters = {"broadcast.fail.percent", "20"})
+```
+
+
 {{% alert title="提示" color="primary" %}}
 `2.1.0` 开始支持
 {{% /alert %}}

--- a/content/zh/docs/v2.7/user/examples/fault-tolerent-strategy.md
+++ b/content/zh/docs/v2.7/user/examples/fault-tolerent-strategy.md
@@ -71,10 +71,11 @@ description: "集群调用失败时，Dubbo 提供的容错方案"
 广播调用所有提供者，逐个调用，任意一台报错则报错。通常用于通知所有提供者更新缓存或日志等本地资源信息。
 
 现在广播调用中，可以通过 broadcast.fail.percent 配置节点调用失败的比例，当达到这个比例后，BroadcastClusterInvoker
-将不再调用其他节点，直接抛出异常. broadcast.fail.percent 取值在 0～100 范围内。默认情况下当全部调用失败后，才会抛出异常。
-broadcast.fail.percent 只是控制的当失败后是否继续调用其他节点，并不改变结果(任意一台报错则报错)。
+将不再调用其他节点，直接抛出异常。 broadcast.fail.percent 取值在 0～100 范围内。默认情况下当全部调用失败后，才会抛出异常。
+broadcast.fail.percent 只是控制的当失败后是否继续调用其他节点，并不改变结果(任意一台报错则报错)。broadcast.fail.percent 参数
+在 dubbo2.7.10 及以上版本生效。
 
-Broadcast Cluster 配置 broadcast.fail.percent.
+Broadcast Cluster 配置 broadcast.fail.percent。
 
 broadcast.fail.percent=20 代表了当 20% 的节点调用失败就抛出异常，不再调用其他节点。
 


### PR DESCRIPTION
The broadcast.fail.percent parameter is added to the broadcast cluster to control whether to continue to call other nodes after the node call fails. By default, an exception is thrown after all nodes are called.

see more details from https://github.com/apache/dubbo/pull/7174
