### PR TITLE
Revert "Use .asf.yaml for publishing"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,2 +1,0 @@
-publish:
-  whoami: asf-site


### PR DESCRIPTION
Reverts apache/dubbo-website#782 due to incorrect branch