### PR TITLE
修正图片路径

### DIFF
--- a/content/zh/docs/v2.7/dev/source/export-service.md
+++ b/content/zh/docs/v2.7/dev/source/export-service.md
@@ -1417,7 +1417,7 @@ CuratorZookeeperClient 构造方法主要用于创建和启动 CuratorFramework 
 
 以 Zookeeper 为例，所谓的服务注册，本质上是将服务配置数据写入到 Zookeeper 的某个路径的节点下。为了让大家有一个直观的了解，下面我们将 Dubbo 的 demo 跑起来，然后通过 Zookeeper 可视化客户端 [ZooInspector](https://github.com/apache/zookeeper/tree/b79af153d0f98a4f3f3516910ed47234d7b3d74e/src/contrib/zooinspector) 查看节点数据。如下：
 
-![](static/imgs/dev/service-registry.png)
+![](/imgs/dev/service-registry.png)
 
 从上图中可以看到 com.alibaba.dubbo.demo.DemoService 这个服务对应的配置信息（存储在 URL 中）最终被注册到了 /dubbo/com.alibaba.dubbo.demo.DemoService/providers/ 节点下。搞懂了服务注册的本质，那么接下来我们就可以去阅读服务注册的代码了。服务注册的接口为 register(URL)，这个方法定义在 FailbackRegistry 抽象类中。代码如下：
 


### PR DESCRIPTION
在https://dubbo.apache.org/zh/docs/v2.7/dev/source/export-service/#2242-%E8%8A%82%E7%82%B9%E5%88%9B%E5%BB%BA    中加载不到图片；
![image](https://user-images.githubusercontent.com/22071212/124691654-bab6a400-df0e-11eb-942d-74e2e3108419.png)
图片在https://dubbo.apache.org/imgs/dev/service-registry.png 是有的。