### PR TITLE
Fix requirement abort java version

### DIFF
--- a/content/en/docs/v2.7/dev/build.md
+++ b/content/en/docs/v2.7/dev/build.md
@@ -25,7 +25,7 @@ Dubbo relies on [maven](http://maven.apache.org) as the building tool.
 
 Requirements:
 
-* Java above 1.5 version
+* Java above 1.8 version
 * Maven version 2.2.1 or above    
 
 The following `MAVEN_OPTS`should be configured before building:

--- a/content/zh/docs/v2.7/dev/build.md
+++ b/content/zh/docs/v2.7/dev/build.md
@@ -24,7 +24,7 @@ Dubbo 使用 [maven](http://maven.apache.org) 作为构建工具。
 
 要求
 
-* Java 1.5 以上的版本
+* Java 1.8 以上的版本
 * Maven 2.2.1 或者以上的版本   
 
 构建之前需要配置以下的 `MAVEN_OPTS`


### PR DESCRIPTION
Fix requirement abort java version. Because there is a lot of use of java1.8 feature.