### PR TITLE
Fix requirement abort java version(CN)

### DIFF
--- a/content/zh/docs/v2.7/dev/build.md
+++ b/content/zh/docs/v2.7/dev/build.md
@@ -24,7 +24,7 @@ Dubbo 使用 [maven](http://maven.apache.org) 作为构建工具。
 
 要求
 
-* Java 1.5 以上的版本
+* Java 1.8 以上的版本
 * Maven 2.2.1 或者以上的版本   
 
 构建之前需要配置以下的 `MAVEN_OPTS`


### PR DESCRIPTION
Fix requirement abort java version. Because there is a lot of use of java1.8 feature.（CN）