### PR TITLE
fix quick start doc

### DIFF
--- a/content/zh/docs/languages/java/quick-start.md
+++ b/content/zh/docs/languages/java/quick-start.md
@@ -20,7 +20,7 @@ $ cd dubbo-samples/dubbo-samples-protobuf
 ## 快速运行示例
 在 dubbo-samples-protobuf 目录
 
-1. 编译示例项目
+1. 编译并打包示例项目
 ```shell script
 $ mvn clean package
 ```

--- a/content/zh/docs/languages/java/quick-start.md
+++ b/content/zh/docs/languages/java/quick-start.md
@@ -22,17 +22,17 @@ $ cd dubbo-samples/dubbo-samples-protobuf
 
 1. 编译示例项目
 ```shell script
-$ mvn clean compile
+$ mvn clean package
 ```
 
 2. 运行 Provider
 ```shell script
-$ java -jar ./dubbo-samples-protobuf/protobuf-provider/target/protobuf-provider-1.0-SNAPSHOT.jar 
+$ java -jar ./protobuf-provider/target/protobuf-provider-1.0-SNAPSHOT.jar 
 ```
 
 3. 运行 consumer
 ```shell script
-$ java -jar ./dubbo-samples-protobuf/protobuf-provider/target/protobuf-consumer-1.0-SNAPSHOT.jar 
+$ java -jar ./protobuf-consumer/target/protobuf-consumer-1.0-SNAPSHOT.jar 
 
 输出以下结果
 result: Hello Hello, response from provider: 30.225.20.43:20880


### PR DESCRIPTION
1.  将 `compile` 改为 `package`， package 之后才有 jar 包
2.  将路径前缀`/dubbo-samples-protobuf`去掉，上面的步骤已经 cd 到这个目录了
3.  运行 consumer 时的路径改为 `protobuf-consumer` ，而不是 `protobuf-provider`