### PR TITLE
Fix doc group-merger

### DIFF
--- a/content/zh/docs/advanced/group-merger.md
+++ b/content/zh/docs/advanced/group-merger.md
@@ -8,7 +8,7 @@ description: "通过分组对结果进行聚合并返回聚合后的结果"
 
 通过分组对结果进行聚合并返回聚合后的结果，比如菜单服务，用group区分同一接口的多种实现，现在消费方需从每种group中调用一次并返回结果，对结果进行合并之后返回，这样就可以实现聚合菜单项。  
 
-相关代码可以参考 [dubbo 项目中的示例](https://github.com/apache/dubbo-samples/tree/master/java/dubbo-samples-merge)
+相关代码可以参考 [dubbo 项目中的示例](https://github.com/apache/dubbo-samples/tree/master/dubbo-samples-merge)
 
 ## 配置
 

--- a/content/zh/docsv2.7/user/examples/group-merger.md
+++ b/content/zh/docsv2.7/user/examples/group-merger.md
@@ -8,7 +8,7 @@ description: "通过分组对结果进行聚合并返回聚合后的结果"
 
 通过分组对结果进行聚合并返回聚合后的结果，比如菜单服务，用group区分同一接口的多种实现，现在消费方需从每种group中调用一次并返回结果，对结果进行合并之后返回，这样就可以实现聚合菜单项。  
 
-相关代码可以参考 [dubbo 项目中的示例](https://github.com/apache/dubbo-samples/tree/master/java/dubbo-samples-merge)
+相关代码可以参考 [dubbo 项目中的示例](https://github.com/apache/dubbo-samples/tree/master/dubbo-samples-merge)
 
 ## 配置
 


### PR DESCRIPTION
https://dubbo.apache.org/zh/docs/advanced/group-merger/ 中的dubbo 项目中的示例链接不正确
![image](https://user-images.githubusercontent.com/17539174/131963127-3197e308-9d92-473d-9ee7-3b44aa2f3076.png)
