### PR TITLE
Fix doc parameter-validation

### DIFF
--- a/content/zh/docs/advanced/parameter-validation.md
+++ b/content/zh/docs/advanced/parameter-validation.md
@@ -186,8 +186,8 @@ public class ValidationConsumer {
 ```
 
 {{% alert title="提示" color="primary" %}}
-自 `2.1.0` 版本开始支持, 如何使用可以参考 [dubbo 项目中的示例代码](https://github.com/apache/dubbo-samples/tree/master/java/dubbo-samples-validation)
+自 `2.1.0` 版本开始支持, 如何使用可以参考 [dubbo 项目中的示例代码](https://github.com/apache/dubbo-samples/tree/master/dubbo-samples-validation)
 
-验证方式可扩展，扩展方式参见开发者手册中的[验证扩展](../../../dev/impls/validation)
+验证方式可扩展，扩展方式参见开发者手册中的[验证扩展](../../references/spis/validation)
 {{% /alert %}}
 


### PR DESCRIPTION
https://dubbo.apache.org/zh/docs/advanced/parameter-validation/ 中的dubbo 项目中的示例代码和验证扩展的链接错误

![image](https://user-images.githubusercontent.com/17539174/131964246-dbb001df-6615-47d8-a80b-29f442ba23af.png)
