### PR TITLE
Fix doc result-cache

### DIFF
--- a/content/zh/docs/advanced/result-cache.md
+++ b/content/zh/docs/advanced/result-cache.md
@@ -14,7 +14,7 @@ description: "通过缓存结果加速访问速度"
 * `threadlocal` 当前线程缓存，比如一个页面渲染，用到很多 portal，每个 portal 都要去查用户信息，通过线程缓存，可以减少这种多余访问。
 * `jcache` 与 [JSR107](http://jcp.org/en/jsr/detail?id=107%27) 集成，可以桥接各种缓存实现。
 
-缓存类型可扩展，参见：[缓存扩展](../../../dev/impls/cache)
+缓存类型可扩展，参见：[缓存扩展](../../references/spis/cache)
 
 ## 配置
 


### PR DESCRIPTION
https://dubbo.apache.org/zh/docs/advanced/result-cache/ 中的缓存扩展链接错误

![image](https://user-images.githubusercontent.com/17539174/131966225-4afd7dfa-2d82-4b8b-bc28-800460faad43.png)
