### PR TITLE
Fix doc context

### DIFF
--- a/content/zh/docs/advanced/context.md
+++ b/content/zh/docs/advanced/context.md
@@ -6,7 +6,7 @@ weight: 19
 description: "通过上下文存放当前调用过程中所需的环境信息"
 ---
 
-上下文中存放的是当前调用过程中所需的环境信息。所有配置信息都将转换为 URL 的参数，参见 [schema 配置参考手册](../references/xml) 中的**对应URL参数**一列。
+上下文中存放的是当前调用过程中所需的环境信息。所有配置信息都将转换为 URL 的参数，参见 [schema 配置参考手册](../../references/xml) 中的**对应URL参数**一列。
 
 RpcContext 是一个 ThreadLocal 的临时状态记录器，当接收到 RPC 请求，或发起 RPC 请求时，RpcContext 的状态都会变化。比如：A 调 B，B 再调 C，则 B 机器上，在 B 调 C 之前，RpcContext 记录的是 A 调 B 的信息，在 B 调 C 之后，RpcContext 记录的是 B 调 C 的信息。
 

--- a/content/zh/docsv2.7/user/examples/context.md
+++ b/content/zh/docsv2.7/user/examples/context.md
@@ -6,7 +6,7 @@ weight: 19
 description: "通过上下文存放当前调用过程中所需的环境信息"
 ---
 
-上下文中存放的是当前调用过程中所需的环境信息。所有配置信息都将转换为 URL 的参数，参见 [schema 配置参考手册](../references/xml) 中的**对应URL参数**一列。
+上下文中存放的是当前调用过程中所需的环境信息。所有配置信息都将转换为 URL 的参数，参见 [schema 配置参考手册](../../references/xml) 中的**对应URL参数**一列。
 
 RpcContext 是一个 ThreadLocal 的临时状态记录器，当接收到 RPC 请求，或发起 RPC 请求时，RpcContext 的状态都会变化。比如：A 调 B，B 再调 C，则 B 机器上，在 B 调 C 之前，RpcContext 记录的是 A 调 B 的信息，在 B 调 C 之后，RpcContext 记录的是 B 调 C 的信息。
 


### PR DESCRIPTION
https://dubbo.apache.org/zh/docs/advanced/context/ 中的schema 配置参考手册链接错误

![image](https://user-images.githubusercontent.com/17539174/132093216-4efd1717-a645-4bcb-8817-59b42336b75f.png)
