### PR TITLE
Fix doc concurrency-control

### DIFF
--- a/content/zh/docs/advanced/concurrency-control.md
+++ b/content/zh/docs/advanced/concurrency-control.md
@@ -57,7 +57,7 @@ description: "Dubbo 中的并发控制"
 </dubbo:service>
 ```
 
-如果 `<dubbo:service>` 和 `<dubbo:reference>` 都配了actives，`<dubbo:reference>` 优先，参见：[配置的覆盖策略](../../configuration/xml)。
+如果 `<dubbo:service>` 和 `<dubbo:reference>` 都配了actives，`<dubbo:reference>` 优先，参见：[配置的覆盖策略](../../references/configuration/xml)。
 
 ## Load Balance 均衡
 


### PR DESCRIPTION
https://dubbo.apache.org/zh/docsv2.7/user/examples/concurrency-control/ 中的配置的覆盖策略链接错误。

![image](https://user-images.githubusercontent.com/17539174/132093515-f641666c-57d9-4b3c-a83c-f25b25742f8c.png)
