### PR TITLE
fix xml.md error link

### DIFF
--- a/content/zh/docs/references/configuration/xml.md
+++ b/content/zh/docs/references/configuration/xml.md
@@ -6,7 +6,7 @@ weight: 30
 description: "以 XML 配置的方式来配置你的 Dubbo 应用"
 ---
 
-有关 XML 的详细配置项，请参见：[XML配置参考手册](../../../references/xml)。如果不想使用 Spring 配置，而希望通过 API 的方式进行调用，请参见：[API配置](../api)。想知道如何使用配置，请参见：[快速启动](../../quick-start)。
+有关 XML 的详细配置项，请参见：[XML配置参考手册](../../../references/xml)。如果不想使用 Spring 配置，而希望通过 API 的方式进行调用，请参见：[API配置](../api)。想知道如何使用配置，请参见：[快速启动](../../../quick-start)。
 
 请在此查看文档描述的[完整示例](https://github.com/apache/dubbo-samples/tree/master/java/dubbo-samples-basic)
 

--- a/content/zh/docs/references/configuration/xml.md
+++ b/content/zh/docs/references/configuration/xml.md
@@ -8,7 +8,7 @@ description: "以 XML 配置的方式来配置你的 Dubbo 应用"
 
 有关 XML 的详细配置项，请参见：[XML配置参考手册](../../../references/xml)。如果不想使用 Spring 配置，而希望通过 API 的方式进行调用，请参见：[API配置](../api)。想知道如何使用配置，请参见：[快速启动](../../../quick-start)。
 
-请在此查看文档描述的[完整示例](https://github.com/apache/dubbo-samples/tree/master/java/dubbo-samples-basic)
+请在此查看文档描述的[完整示例](https://github.com/apache/dubbo-samples/tree/master/dubbo-samples-basic)
 
 ## provider.xml 示例
 


### PR DESCRIPTION
这个页面的两个链接错误  https://dubbo.apache.org/zh/docs/references/configuration/xml/

![image](https://user-images.githubusercontent.com/17539174/133934048-24067718-f0ab-4ff3-b1bc-1657af1ea09e.png)
