### PR TITLE
fix URL error

### DIFF
--- a/content/zh/docs3-v2/_index.md
+++ b/content/zh/docs3-v2/_index.md
@@ -33,7 +33,7 @@ menu:
         <div class="h-100 card shadow">
             <div class="card-body">
                 <h4 class="card-title">
-                    <a href='{{< relref "./java-sdk" >}}'>Golang SDK</a>
+                    <a href='{{< relref "./golang-sdk" >}}'>Golang SDK</a>
                 </h4>
                 <p>Dubbo Golang SDK 手册</p>
             </div>

--- a/content/zh/release/go.md
+++ b/content/zh/release/go.md
@@ -9,7 +9,7 @@ weight: 2
 
 可以按照这里的[步骤](https://www.apache.org/info/verification), 利用[KEYS](https://downloads.apache.org/dubbo/KEYS)文件来验证下载。
 
-> GitHub: https://github.com/apache/dubbo-go-pixiu \
-> 发布说明: https://github.com/apache/dubbo-go-pixiu/releases
+> GitHub: https://github.com/apache/dubbo-go \
+> 发布说明: https://github.com/apache/dubbo-go/releases
 >
 


### PR DESCRIPTION
Problem description：
1.Clicking golang will jump to Java
2.The address of dubbo-go is dubbo-go-pixiu
