### PR TITLE
docs: add button to help & use Gitpod for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This project contains the hugo project, markdown files, and theme configurations
 
 ## Environment setup
 
+You can directly start working on this repository even from your browser by just clicking on the following button
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/apache/dubbo-website)
+
+Or, you can follow the manual steps given below.
+
 1. Ensure pre-requisites are installed
 2. Clone this repository
 ```sh


### PR DESCRIPTION
We saw that maintainers already [Gitpodified](https://www.gitpod.io/blog/gitpodify/) this repository in in https://github.com/apache/dubbo-website/pull/1265 to ease out the life of contributors to use [Gitpod](https://gitpod.io/) & instead of setting up manual development environments. Just a single button. to get started. But, to make awareness for new contributors. There is missing information about the project, that they can also start building in Gitpod.