### PR TITLE
cluster-faq建设

### DIFF
--- a/content/zh/docs3-v2/java-sdk/faq/2/4.md
+++ b/content/zh/docs3-v2/java-sdk/faq/2/4.md
@@ -1,0 +1,17 @@
+---
+type: docs
+title: "2-4 - Merger接口加载失败"
+linkTitle: "2-4 - Merger接口加载失败"
+weight: 2
+---
+
+## 可能的原因
+
+* dubbo提供了聚合下游所有提供方响应的SPI扩展Merger接口，dubbo在加载用户在自定义扩展Merger接口时，加载配置失败。
+
+## 排查和解决步骤
+1. 参照社区SPI扩展使用手册，检查用户自定义扩展Merger接口实现，[《SPI 扩展使用手册》](https://dubbo.apache.org/zh/docs3-v2/java-sdk/reference-manual/spi/)。
+
+
+
+<p style="margin-top: 3rem;"> </p>


### PR DESCRIPTION
新增2-4错误码：dubbo提供了聚合下游所有提供方响应的SPI扩展Merger接口，dubbo在加载用户在自定义扩展Merger接口时，加载配置失败。