### PR TITLE
Improve docs struct

### DIFF
--- a/content/en/docs/v3.0/languages/rust/_index.md
+++ b/content/en/docs/v3.0/languages/rust/_index.md
@@ -1,0 +1,10 @@
+
+---
+type: docs
+title: "Rust"
+linkTitle: "Rust"
+weight: 200
+description: "Dubbo-rust support"
+manualLinkRelref: ../../../../docs3-v2/rust-sdk/
+---
+

--- a/content/en/docs3-v2/erlang-sdk/_index.md
+++ b/content/en/docs3-v2/erlang-sdk/_index.md
@@ -1,0 +1,10 @@
+
+---
+type: docs
+title: "Erlang"
+linkTitle: "Erlang"
+weight: 500
+description: "Erlang SDK Manual"
+manualLinkRelref: ../../../docs/v3.0/languages/erlang/
+---
+

--- a/content/en/docs3-v2/golang-sdk/_index.md
+++ b/content/en/docs3-v2/golang-sdk/_index.md
@@ -1,0 +1,10 @@
+
+---
+type: docs
+title: "Golang"
+linkTitle: "Golang"
+weight: 20
+description: "Go SDK Manual"
+manualLinkRelref: ../../../docs/v3.0/languages/golang/
+---
+

--- a/content/en/docs3-v2/rust-sdk/java-interoperability.md
+++ b/content/en/docs3-v2/rust-sdk/java-interoperability.md
@@ -67,4 +67,4 @@ reply: GreeterReply { message: "msg3 from server" }
 trailer: Some(Metadata { inner: {"content-type": "application/grpc", "grpc-message": "poll trailer successfully.", "grpc-accept-encoding": "gzip,identity", "grpc-status": "0"} })
 ```
 
-[The interface defination on Rust side](https://github.com/apache/dubbo-samples/tree/master/dubbo-samples-triple)
+[The interface defination on Rust side](https://github.com/apache/dubbo-rust/blob/main/examples/greeter/proto/greeter.proto)

--- a/content/zh/overview/_index.md
+++ b/content/zh/overview/_index.md
@@ -30,8 +30,9 @@ Dubbo 是一款包含多种语言实现（Java、Golang等）的 RPC 服务框�
 #### 相关链接
 Dubbo 的多语言实现及文档:
 
-Language | OS | Compilers/SDK  
--- | -- | -- 
-Go|Windows, Linux, Mac|Go 1.13+  
-Java|Windows, Linux, Mac|Java 8+  
+Language | OS | Compilers/SDK | 参考文档 |
+-- | -- | -- | -- |
+Go|Windows, Linux, macOS |Go 1.13+ | [Go](../docs3-v2/golang-sdk) |
+Java|Windows, Linux, macOS |Java 8+ | [Java](../docs3-v2/java-sdk/) |
+Rust | Windwos, Linux, macOS | Rust 2021 edition | [Rust](../docs3-v2/rust-sdk) |
 


### PR DESCRIPTION
Align English doc struct with the Chinese version.
对齐英文文档和中文文档结构。

1. 
<img src="https://user-images.githubusercontent.com/1926185/193176824-ec70d390-913b-4251-9190-e4a122df5d3a.png" width="250"> with <img src="https://user-images.githubusercontent.com/1926185/193176915-28be2728-a02b-427a-bb76-ff3d3abd4075.png" width="300">

2. 
<img src="https://user-images.githubusercontent.com/1926185/193177007-370640d9-b503-4d3e-bd32-57fbfd6824b0.png" width="350"> with <img src="https://user-images.githubusercontent.com/1926185/193176950-1e05b54e-d235-4b2e-bb87-c1e171f8ed2b.png" width="230">
