### PR TITLE
Update spring-boot.md

### DIFF
--- a/content/zh-cn/overview/quickstart/java/spring-boot.md
+++ b/content/zh-cn/overview/quickstart/java/spring-boot.md
@@ -304,7 +304,7 @@ docker run --name some-zookeeper -p 2181:2181 --restart always -d zookeeper
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-samples-spring-boot-interface</artifactId>
+            <artifactId>dubbo-spring-boot-interface</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 


### PR DESCRIPTION
dubbo-spring-boot-consumer 和 dubbo-spring-boot-provider 两个模块 pom.xml 中关于dubbo-spring-boot-demo-interface的依赖，dubbo关键词后面多加了个samples，应该不是dubbo-samples-spring-boot-demo-interface，而是dubbo-spring-boot-demo-interface。（对应的截图也是）