### PR TITLE
typo in spring-boot.md

### DIFF
--- a/content/en/docs3-v2/java-sdk/quick-start/spring-boot.md
+++ b/content/en/docs3-v2/java-sdk/quick-start/spring-boot.md
@@ -411,7 +411,7 @@ public interface DemoService {
 }
 ```
 
-In `GreetingsService`, the `sayHi` method is defined. Subsequent services published by the server and services subscribed by the consumer are all developed around the `GreetingsService` interface.
+In `DemoService`, the `sayHello` method is defined. Subsequent services published by the server and services subscribed by the consumer are all developed around the `DemoService` interface.
 
 
 


### PR DESCRIPTION
It seems that this line may have been copied from a previous tutorial because the current tutorial discusses the DemoService interface and the sayHello method, rather than the GreetingsService interface and the sayHi method.