### PR TITLE
fix: blank link

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16'
       - name: Setup Docsy
         run: git submodule update --init --recursive && sudo npm install -D --save autoprefixer && sudo npm install -D --save postcss-cli
       - name: Setup Hugo
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16'
       - name: Setup Docsy
         run: git submodule update --init --recursive && sudo npm install -D --save autoprefixer && sudo npm install -D --save postcss-cli
       - name: Setup Hugo

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16'
       - name: Setup Docsy
         run: git submodule update --init --recursive && sudo npm install -D --save autoprefixer && sudo npm install -D --save postcss-cli
       - name: Setup Hugo

--- a/content/en/docs3-v2/golang-sdk/tutorial/governance/features/custom-filter.md
+++ b/content/en/docs3-v2/golang-sdk/tutorial/governance/features/custom-filter.md
@@ -25,7 +25,7 @@ Filter adopts the idea of aspect-oriented design. Through reasonable expansion o
 
 ## 2. Framework predefined Filter
 
-The framework predefines a series of filters, which can be used directly in the configuration, and its code implementation is located at [filter](https://github.com/apache/dubbo-go/tree/3.0/filter)
+The framework predefines a series of filters, which can be used directly in the configuration, and its code implementation is located at [filter](https://github.com/apache/dubbo-go/tree/release-3.0/filter)
 
 - accesslog
 - active

--- a/content/zh-cn/blog/golang/dubbo-go-config-center.md
+++ b/content/zh-cn/blog/golang/dubbo-go-config-center.md
@@ -254,7 +254,7 @@ func newApolloConfiguration(url *common.URL) (*apolloConfiguration, error) {
 
 而 Parser & SetParser 使用默认实现即可，默认为 Properties 转换器。
 
-更多信息，参考：dubbo-go-apollo ，详情参考： https://github.com/apache/dubbo-go/tree/1.5/config_center/apollo
+更多信息，参考：dubbo-go-apollo ，详情参考： https://github.com/apache/dubbo-go/tree/release-1.5/config_center/apollo
 
 ### 使用方法
 

--- a/content/zh-cn/blog/golang/dubbogo-from-scratch.md
+++ b/content/zh-cn/blog/golang/dubbogo-from-scratch.md
@@ -842,7 +842,7 @@ dubbogo 主要有三个配置文件：
 
 
 
-篇幅有限，就介绍到这里。欢迎有兴趣的同学来参与 [dubbogo3.0](https://github.com/apache/dubbo-go/tree/3.0) 的建设，感谢阅读。
+篇幅有限，就介绍到这里。欢迎有兴趣的同学来参与 [dubbogo3.0](https://github.com/apache/dubbo-go/tree/release-3.0) 的建设，感谢阅读。
 
 
 

--- a/content/zh-cn/blog/news/releases/dubbo-go-1.4.md
+++ b/content/zh-cn/blog/news/releases/dubbo-go-1.4.md
@@ -147,7 +147,7 @@ Dubbo 鉴权认证是为了避免敏感接口被匿名用户调用而在 SDK 层
 
 目前这些规划的 任务清单[^4]，都已经放入在 dubbo-go 项目的 issue 里面，欢迎感兴趣的朋友认领参与开发。dubbo-go 社区在 **钉钉群 23331795** 欢迎你的加入。
 
-[^1]: https://github.com/apache/dubbo-go-samples/tree/1.5/registry/kubernetes
+[^1]: https://github.com/apache/dubbo-go-samples/tree/release-1.5/registry/kubernetes
 [^2]: https://github.com/dubbogo/dubbo-samples/tree/master/golang/router/condition
 [^3]: https://github.com/dubbogo/dubbo-samples/tree/master/golang/configcenter/nacos
 [^4]: https://github.com/apache/dubbo-go/milestone/1

--- a/content/zh-cn/blog/news/releases/dubbo-go-1.5.1.md
+++ b/content/zh-cn/blog/news/releases/dubbo-go-1.5.1.md
@@ -28,7 +28,7 @@ description: >
 
 基于 Seata 扩展实现。通过增加过滤器，在服务端接收  xid 并结合 [seata-golang](https://github.com/seata-golang/seata-golang) 达到支持分布式事务的目的。 从而使 Dubbo-go 在分布式场景下，让用户有更多的选择，能适应更多的个性化场景。
 
-我们在 dubbo-samples 中给出了 [事务测试用例](https://github.com/apache/dubbo-go-samples/tree/1.5/seata) 。
+我们在 dubbo-samples 中给出了 [事务测试用例](https://github.com/apache/dubbo-go-samples/tree/release-1.5/seata) 。
 
 ## 3 多注册中心集群负载均衡
 

--- a/content/zh-cn/docs/languages/golang/dubbo-go-1.5/configuration/client.md
+++ b/content/zh-cn/docs/languages/golang/dubbo-go-1.5/configuration/client.md
@@ -208,4 +208,4 @@ type: docs
    ```
 
 
-本文章源码详情见git：https://github.com/apache/dubbo-go-samples/tree/1.5/helloworld/go-client
+本文章源码详情见git：https://github.com/apache/dubbo-go-samples/tree/release-1.5/helloworld/go-client

--- a/content/zh-cn/docs/languages/golang/dubbo-go-1.5/configuration/provider.md
+++ b/content/zh-cn/docs/languages/golang/dubbo-go-1.5/configuration/provider.md
@@ -206,4 +206,4 @@ type: docs
    ```
 
 
-本文章源码详情见git：https://github.com/apache/dubbo-go-samples/tree/1.5/helloworld/go-server
+本文章源码详情见git：https://github.com/apache/dubbo-go-samples/tree/release-1.5/helloworld/go-server

--- a/content/zh-cn/docs/languages/golang/dubbo-go-3.0/samples/custom-filter.md
+++ b/content/zh-cn/docs/languages/golang/dubbo-go-3.0/samples/custom-filter.md
@@ -36,7 +36,7 @@ Filter 采用面向切面设计的思路，通过对 Filter 的合理扩展，�
 
 ## 2. 框架预定义 Filter
 
-框架预定义了一系列filter，可以在配置中直接使用，其代码实现位于[filter](https://github.com/apache/dubbo-go/tree/3.0/filter)
+框架预定义了一系列filter，可以在配置中直接使用，其代码实现位于[filter](https://github.com/apache/dubbo-go/tree/release-3.0/filter)
 
 - accesslog
 - active

--- a/content/zh-cn/overview/mannual/golang-sdk/tutorial/governance/features/custom-filter.md
+++ b/content/zh-cn/overview/mannual/golang-sdk/tutorial/governance/features/custom-filter.md
@@ -34,7 +34,7 @@ Filter 采用面向切面设计的思路，通过对 Filter 的合理扩展，�
 
 ## 2. 框架预定义 Filter
 
-框架预定义了一系列filter，可以在配置中直接使用，其代码实现位于[filter](https://github.com/apache/dubbo-go/tree/3.0/filter)
+框架预定义了一系列filter，可以在配置中直接使用，其代码实现位于[filter](https://github.com/apache/dubbo-go/tree/release-3.0/filter)
 
 - accesslog
 - active

--- a/static/dubbo-go/v3
+++ b/static/dubbo-go/v3
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta name="go-import" content="dubbo.apache.org/dubbo-go/v3 git https://github.com/apache/dubbo-go">
-    <meta name="go-source" content="dubbo.apache.org/dubbo-go/v3 git https://github.com/apache/dubbo-go/tree/3.0{/dir} https://github.com/apache/dubbo-go/blob/3.0{/dir}/{file}#L{line}">
+    <meta name="go-source" content="dubbo.apache.org/dubbo-go/v3 git https://github.com/apache/dubbo-go/tree/release-3.0{/dir} https://github.com/apache/dubbo-go/blob/release-3.0{/dir}/{file}#L{line}">
     <meta http-equiv="refresh" content="0; url=https://pkg.go.dev/dubbo.apache.org/dubbo-go/v3">
   </head>
   <body>


### PR DESCRIPTION
Hi, dubbo is an awosome project. When I read the document, I find the link is pointing to a blank page. It maybe cause by the name of [dubbo-go](https://github.com/apache/dubbo-go/tree/release-3.0) branch changed. I fix it by useing the current branch name. Please review.

![image](https://user-images.githubusercontent.com/71440988/228896502-192c2581-494a-4e62-89e0-d11f64170dd5.png)
