### PR TITLE
fixed protocol.name wrong spelling

### DIFF
--- a/content/en/overview/mannual/java-sdk/tasks/develop/springboot.md
+++ b/content/en/overview/mannual/java-sdk/tasks/develop/springboot.md
@@ -61,7 +61,7 @@ dubbo:
     name: dubbo-springboot-demo-provider
     logger: slf4j
   protocol:
-    name: triple
+    name: tri
     port: -1
   registry:
     address: zookeeper://127.0.0.1:2181
@@ -76,7 +76,7 @@ dubbo:
   application:
     name: dubbo-springboot-demo-provider
   protocol:
-    name: triple
+    name: tri
     port: -1
   registry:
     id: zk-registry

--- a/content/zh-cn/overview/mannual/java-sdk/tasks/develop/springboot.md
+++ b/content/zh-cn/overview/mannual/java-sdk/tasks/develop/springboot.md
@@ -67,7 +67,7 @@ dubbo:
     name: dubbo-springboot-demo-provider
     logger: slf4j
   protocol:
-    name: triple
+    name: tri
     port: -1
   registry:
     address: zookeeper://127.0.0.1:2181
@@ -82,7 +82,7 @@ dubbo:
   application:
     name: dubbo-springboot-demo-provider
   protocol:
-    name: triple
+    name: tri
     port: -1
   registry:
     id: zk-registry


### PR DESCRIPTION
close #3044 

Before:
```yaml
dubbo:
  protocol:
    name: triple
    port: -1
```

After:
```yaml
dubbo:
  protocol:
    name: tri
    port: -1
```

In addition, if the `tri` way of writing is correct, does Rust-SDK also need to be replaced?
https://github.com/apache/dubbo-website/blob/master/content/en/overview/mannual/rust-sdk/quick-start.md?plain=1#L168-L173