### PR TITLE
Remove Google & Baidu Analytics from Dubbo Website - fixes #3087

### DIFF
--- a/cn_config.toml
+++ b/cn_config.toml
@@ -42,7 +42,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "G-NM6FFMT51J"
+##id = "G-NM6FFMT51J"
 
 staticDir = ["static"]
 

--- a/config.toml
+++ b/config.toml
@@ -42,7 +42,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "G-1TFHM5YBH0"
+## id = "G-1TFHM5YBH0"
 
 staticDir = ["static"]
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,18 +15,6 @@
 {{ else }}
 <link rel="canonical" href="{{ .Permalink }}">
 {{ end }}
-{{ if $.Site.Params.cn_site }}
-<script>
-    var _hmt = _hmt || [];
-    (function() {
-        var hm = document.createElement("script");
-        hm.src = "https://hm.baidu.com/hm.js?3b78f49ba47181e4d998a66b689446e9";
-        var s = document.getElementsByTagName("script")[0];
-        s.parentNode.insertBefore(hm, s);
-    })();
-</script>
-
-{{ end }}
 
 <!-- Docsy head.html begins here -->
 <meta charset="utf-8">


### PR DESCRIPTION
See https://github.com/apache/dubbo-website/issues/3087