### PR TITLE
Fix typo in Golang SDK/Quickstart guide (refs apache/dubbo-go#2805)

### DIFF
--- a/content/en/overview/mannual/golang-sdk/quickstart/rpc.md
+++ b/content/en/overview/mannual/golang-sdk/quickstart/rpc.md
@@ -28,7 +28,7 @@ Since we are using Protocol Buffer, we first need to install the relevant code g
 
     ```shell
     go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-    go install dubbo.apache.org/dubbo-go/v3/cmd/protoc-gen-go-triple@v3.0.1
+    go install github.com/dubbogo/protoc-gen-go-triple/v3@v3.0.2
     ```
 
     Make sure `protoc-gen-go` and `protoc-gen-go-triple` are in your `PATH`. You can verify this with `which protoc-gen-go`. If that command does not work, please execute the following commands:


### PR DESCRIPTION
## What this PR does

This PR fixes a typo in the [Quick Start guide of Golang SDK](https://dubbo.apache.org/en/overview/mannual/golang-sdk/quickstart/rpc/) on the Dubbo website.

## Related Issue

Fixes apache/dubbo-go#2805

## Changes

- Corrected a typo in the installation command for `protoc-gen-go-triple`

## Notes

This issue was originally reported in the [dubbo-go](https://github.com/apache/dubbo-go) repository.
