### PR TITLE
修正Java-Doc中-服务降级文档页的拼写错误

### DIFF
--- a/content/zh-cn/overview/mannual/java-sdk/tasks/framework/more/local-mock.md
+++ b/content/zh-cn/overview/mannual/java-sdk/tasks/framework/more/local-mock.md
@@ -7,7 +7,7 @@ aliases:
     - /zh-cn/overview/mannual/java-sdk/advanced-features-and-usage/service/local-mock/
 description: 了解如何在 Dubbo 中利用本地伪装实现服务降级
 linkTitle: 服务降级
-title: 服务讲解（本地伪装）
+title: 服务降级（本地伪装）
 type: docs
 weight: 10
 ---


### PR DESCRIPTION
# 错误点
<img width="925" alt="image" src="https://github.com/user-attachments/assets/d89f918d-566e-4164-9a82-7f3dc2c4254e" />

# 修正

服务讲解（本地伪装） ==> 服务降级（本地伪装）

