### PR TITLE
Fix nacos console url

### DIFF
--- a/content/en/overview/reference/integrations/nacos.md
+++ b/content/en/overview/reference/integrations/nacos.md
@@ -36,7 +36,7 @@ startup.cmd -m standalone
 
 #### Verify Nacos Started Normally
 
-Access the console via the browser at the following link: http://127.0.0.1:8848/nacos/
+Access the console via the browser at the following link: http://127.0.0.1:8080/index.html
 
 ## Docker
 To start Nacos using Docker, please ensure you have properly <a href="https://docs.docker.com/engine/install/" target="_blank">installed Docker</a> on your local machine.

--- a/content/zh-cn/overview/reference/integrations/nacos.md
+++ b/content/zh-cn/overview/reference/integrations/nacos.md
@@ -36,7 +36,7 @@ startup.cmd -m standalone
 
 #### 验证 nacos 正常启动
 
-通过浏览器访问以下链接打开控制台：http://127.0.0.1:8848/nacos/
+通过浏览器访问以下链接打开控制台：http://127.0.0.1:8080/index.html
 
 ## docker
 下载 nacos-docker 项目。


### PR DESCRIPTION
The console url of Nacos is `http://127.0.0.1:8080/index.html`.  