### PR TITLE
Add "hugo" label to .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,6 +20,8 @@ github:
   homepage: https://dubbo.apache.org/
   labels:
     - dubbo
+    - website
+    - hugo
   enabled_merge_buttons:
     squash:  true
     merge:   false


### PR DESCRIPTION
### Add "hugo" label to .asf.yaml

The Infra team would like projects to use [Topics in GitHub](https://infra.apache.org/project-site.html#svnpubsub-revision) to label **_website_** repositories and indicate the **_TOOL_** (such as **_hugo_**) used to generate the site.

This can be done through the [.asf.yaml](https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#repository-metadata) file using **_labels_**

These labels/topics can be used by other ASF projects to find site using a specified technology - for example [using this GitHub Query](https://github.com/search?q=topic%3Ahugo+org%3Aapache&type=Repositories) to find other sites that use Hugo.