### PR TITLE
fix(i18n): preserve selected language in footer navigation

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -299,7 +299,7 @@ other = "/en/overview/quickstart/"
 other = "Developer guide"
 
 [footer_right_link_developer]
-other = "/zh-cn/contact/contributor/software-donation-guide_dev/"
+other = "/en/contact/contributor/software-donation-guide_dev/"
 
 [footer_right_title2]
 other = "RESOURCES"
@@ -308,5 +308,5 @@ other = "RESOURCES"
 other = "Community"
 
 [footer_right_link_community]
-other = "/zh-cn/contact/"
+other = "/en/contact/"
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where footer links such as **Developer Guide** and **Community** did not preserve the selected language.

When the website language was set to English, these links redirected users to Chinese pages even though English versions of the pages exist.

### Related issue
Fixes #3175

### How was this tested?
- Set site language to English
- Clicked footer links (Developer Guide, Community)
- Verified navigation stays on English pages
