### PR TITLE
fix(website): preserve page context when switching language on desktop

### DIFF
--- a/layouts/partials/navbar-lang-selector.html
+++ b/layouts/partials/navbar-lang-selector.html
@@ -17,8 +17,16 @@
 
 <div class="nav nav-tabs languagetab-contain " id="languageTabs" role="tablist">
   {{ range $langCode, $langURL := $languages }}
+  {{ $targetURL := $langURL }}
+  {{ if $langPage.Language }}
+    {{ range $langPage.Translations }}
+      {{ if eq .Language.LanguageName $langCode }}
+        {{ $targetURL = .RelPermalink }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
   <a class="languagetab-btn nav-item nav-link {{ if eq $langCode $currentLangCode }}active{{ end }}"
-    href="{{ $langURL }}" role="tab" aria-selected="{{ if eq $langCode $currentLangCode }}true{{ else }}false{{ end }}">
+    href="{{ $targetURL }}" role="tab" aria-selected="{{ if eq $langCode $currentLangCode }}true{{ else }}false{{ end }}">
     {{ $langCode }}
   </a>
   {{ end }}


### PR DESCRIPTION
### What is the purpose of the change
When switching languages from a page other than the homepage (for example, documentation pages), the language switcher currently redirects users to the homepage of the selected language in desktop view.

This change ensures that desktop users remain on the same page when switching languages, preserving reading context and improving user experience.

### Brief changelog
- Updated language switcher to resolve correct translated page URL when available
- Falls back gracefully when translation does not exist

### Verifying this change
- Open a documentation page
- Switch language using the language selector
- User remains on the same page in the selected language

### GitHub Issue
Fixes #3176
