### PR TITLE
docs(golang-sdk): add OpenTelemetry trace integration documentation

### DIFF
--- a/content/en/overview/mannual/golang-sdk/tutorial/observability/logger.md
+++ b/content/en/overview/mannual/golang-sdk/tutorial/observability/logger.md
@@ -76,3 +76,32 @@ srv, err := server.NewServer(
 
 For `true` and `default`, the access log will be printed using the logger component in Dubbo. If a specific log file path is specified, it will be written directly to that file.
 
+## 4. OpenTelemetry Trace Integration
+
+You can enable trace integration via `log.WithTraceIntegration(true)`:
+
+```go
+ins, err := dubbo.NewInstance(
+	dubbo.WithLogger(
+		log.WithLevel("warn"),
+		log.WithZap(),
+		log.WithTraceIntegration(true),  // enable trace integration
+		log.WithRecordErrorToSpan(true), // record errors to span
+		),
+)
+```
+
+Once OpenTelemetry tracer is enabled, you can log with trace context using `CtxLogger`:
+
+```go
+ctxLog.CtxInfo(ctx, "hello dubbogo this is info log")
+ctxLog.CtxDebug(ctx, "hello dubbogo this is debug log")
+ctxLog.CtxWarn(ctx, "hello dubbogo this is warn log")
+ctxLog.CtxError(ctx, "hello dubbogo this is error log")
+
+ctxLog.CtxInfof(ctx, "user: %s", "alice")
+ctxLog.CtxDebugf(ctx, "value: %d", 42)
+ctxLog.CtxWarnf(ctx, "latency: %dms", 150)
+ctxLog.CtxErrorf(ctx, "failed: %v", err)
+```
+

--- a/content/zh-cn/overview/mannual/golang-sdk/tutorial/observability/logger.md
+++ b/content/zh-cn/overview/mannual/golang-sdk/tutorial/observability/logger.md
@@ -75,3 +75,32 @@ srv, err := server.NewServer(
 ```
 
 对于 `true` 和 `default` 而言，访问日志会使用 Dubbo 中的 logger 组件打印出来。如果指定了具体的日志文件路径，则直接写入到该文件。
+
+## 4. OpenTelementry trace 集成
+
+可以通过 `log.WithTraceIntegration(true)` 启用 trace 集成：
+
+```go
+ins, err := dubbo.NewInstance(
+	dubbo.WithLogger(
+		log.WithLevel("warn"),
+		log.WithZap(),
+		log.WithTraceIntegration(true),  // 启用 trace 集成
+		log.WithRecordErrorToSpan(true), // 错误记录到 span
+	),
+)
+```
+
+OpenTelemetry tracer 启用后，可以通过 `CtxLogger` 记录带有 trace 的日志：
+
+```go
+ctxLog.CtxInfo(ctx, "hello dubbogo this is info log")
+ctxLog.CtxDebug(ctx, "hello dubbogo this is debug log")
+ctxLog.CtxWarn(ctx, "hello dubbogo this is warn log")
+ctxLog.CtxError(ctx, "hello dubbogo this is error log")
+
+ctxLog.CtxInfof(ctx, "user: %s", "alice")
+ctxLog.CtxDebugf(ctx, "value: %d", 42)
+ctxLog.CtxWarnf(ctx, "latency: %dms", 150)
+ctxLog.CtxErrorf(ctx, "failed: %v", err)
+```


### PR DESCRIPTION
Add documentation for OpenTelemetry trace integration feature in logger configuration, including:
- How to enable trace integration with log.WithTraceIntegration()
- How to use CtxLogger for logging with trace context