### PR TITLE
docs(#3131): fix configuration item reference manual - spelling error…

### DIFF
--- a/content/en/overview/mannual/java-sdk/reference-manual/config/properties.md
+++ b/content/en/overview/mannual/java-sdk/reference-manual/config/properties.md
@@ -28,7 +28,7 @@ weight: 6
 | dubbo.jstack-dump.max-line | -Ddubbo.jstack-dump.max-line=20 | Dubbo supports automatic printing of the call stack. This parameter controls the number of stack lines, e.g., only the first 20 lines will be printed. |
 | dubbo.json-framework.prefer | -Ddubbo.json-framework.prefer=gson | Sets the specific implementation of JSON serialization in the framework. Currently available implementations are `fastjson2`, `fastjson`, `gson`, `jackson`. The framework automatically finds the available implementation in decreasing order of preference. |
 | dubbo.network.interface.ignored | -Ddubbo.network.interface.ignored=eth1,eth2 | In multi-network card environments, used when you need to manually control the network card address registered with the registry. It is used to exclude certain network cards. |
-| dubbo.network.interface.preferred | -Ddubbo.network.interface.ignored=eth0 | In multi-network card environments, used to specify a particular network card for registration with the registry. |
+| dubbo.network.interface.preferred | -Ddubbo.network.interface.preferred=eth0 | In multi-network card environments, used to specify a particular network card for registration with the registry. |
 | sun.rmi.transport.tcp.responseTimeout | -Dsun.rmi.transport.tcp.responseTimeout=5000 | Sets the timeout for RMI protocol, in milliseconds. |
 | env |  | Specific parameter for Apollo configuration center. |
 | app.id |  | Specific parameter for Apollo configuration center. |

--- a/content/zh-cn/overview/mannual/java-sdk/reference-manual/config/properties.md
+++ b/content/zh-cn/overview/mannual/java-sdk/reference-manual/config/properties.md
@@ -31,7 +31,7 @@ weight: 6
 | dubbo.jstack-dump.max-line | -Ddubbo.jstack-dump.max-line=20 | Dubbo 支持自动打印调用堆栈，这个参数可以控制堆栈行数，如示例中只会打印前20行堆栈 |
 | dubbo.json-framework.prefer| -Ddubbo.json-framework.prefer=gson | 设置框架中 json 序列化的具体实现，目前可选实现有 `fastjson2`、`fastjson`、`gson`、`jackson`。默认情况，框架会自动查找可用实现，以上按顺序优先级依次降低 |
 | dubbo.network.interface.ignored | -Ddubbo.network.interface.ignored=eth1,eth2 | 在多网卡环境下，当需要手动控制注册到注册中心的网卡地址时使用。用于排除某些网卡 |
-| dubbo.network.interface.preferred | -Ddubbo.network.interface.ignored=eth0 | 在多网卡环境下，当需要手动控制注册到注册中心的网卡地址时使用。用于指定一个特定网卡 |
+| dubbo.network.interface.preferred | -Ddubbo.network.interface.preferred=eth0 | 在多网卡环境下，当需要手动控制注册到注册中心的网卡地址时使用。用于指定一个特定网卡 |
 | sun.rmi.transport.tcp.responseTimeout | -Dsun.rmi.transport.tcp.responseTimeout=5000 | 用于设置 RMI 协议下的超时时间，单位ms |
 | env |  | Apollo 配置中心特有参数 |
 | app.id |  | Apollo 配置中心特有参数 |


### PR DESCRIPTION
fix: https://github.com/apache/dubbo-website/issues/3131