### PR TITLE
docs(pixiu): add saml filter docs

### DIFF
--- a/content/en/overview/reference/pixiu/other/user/httpfilter/saml.md
+++ b/content/en/overview/reference/pixiu/other/user/httpfilter/saml.md
@@ -1,0 +1,104 @@
+---
+aliases:
+  - /en/docs3-v2/dubbo-go-pixiu/user/httpfilter/saml/
+  - /en/overview/reference/pixiu/other/user/httpfilter/saml/
+  - /en/overview/mannual/dubbo-go-pixiu/user/httpfilter/saml/
+description: SAML Introduction
+linkTitle: SAML Introduction
+title: SAML Introduction
+type: docs
+weight: 25
+---
+
+# SAML Auth Filter (dgp.filter.http.auth.saml)
+
+---
+
+## English
+
+### Overview
+
+The `dgp.filter.http.auth.saml` filter allows Pixiu to act as a SAML Service Provider (SP).
+
+With this filter enabled, Pixiu can:
+
+- expose SP metadata for IdP registration
+- redirect unauthenticated browser requests to the IdP login page
+- receive the SAML response on the ACS endpoint
+- create a session cookie after a successful login
+- forward selected SAML assertion attributes to upstream services as HTTP headers
+
+Typical IdPs include Keycloak, Okta, and Microsoft Entra ID.
+
+### Request Flow
+
+1. A browser requests a protected Pixiu route such as `/app`.
+2. Pixiu checks whether the request already carries a valid SAML session cookie.
+3. If no valid session exists, Pixiu redirects the browser to the IdP login page.
+4. After the user signs in, the IdP posts a `SAMLResponse` to Pixiu's ACS endpoint.
+5. Pixiu validates the assertion, creates a session cookie, and redirects the browser back to the original route.
+6. Later requests continue to the upstream service, with configured SAML attributes forwarded as headers.
+
+### Minimal Configuration
+
+```yaml
+http_filters:
+  - name: "dgp.filter.http.auth.saml"
+    config:
+      entity_id: "pixiu-saml-sp"
+      acs_url: "https://pixiu.example.com/saml/acs"
+      metadata_url: "https://pixiu.example.com/saml/metadata"
+      idp_metadata_url: "https://idp.example.com/app/metadata"
+      cert_file: "/etc/pixiu/saml/sp.crt"
+      key_file: "/etc/pixiu/saml/sp.key"
+      rules:
+        - match:
+            prefix: "/app"
+      forward_attributes:
+        - saml_attribute: "email"
+          header: "X-User-Email"
+        - saml_attribute: "displayName"
+          header: "X-User-Name"
+```
+
+Instead of `idp_metadata_url`, you can load IdP metadata from a local file:
+
+```yaml
+idp_metadata_file: "/etc/pixiu/saml/idp-metadata.xml"
+```
+
+### Configuration Fields
+
+- `entity_id`: SP entity ID advertised by Pixiu
+- `acs_url`: Assertion Consumer Service endpoint that receives the `SAMLResponse`
+- `metadata_url`: Pixiu SP metadata endpoint shared with the IdP administrator
+- `idp_metadata_url`: URL used by Pixiu to fetch IdP metadata
+- `idp_metadata_file`: local metadata file, used instead of `idp_metadata_url`
+- `cert_file`: SP certificate file
+- `key_file`: SP private key file
+- `rules`: protected path prefixes that require SAML login
+- `forward_attributes`: mapping from SAML assertion attributes to upstream HTTP headers
+- `allow_idp_initiated`: development-focused escape hatch for local HTTP testing when browsers drop the request-tracking cookie on the cross-site ACS POST
+- `err_msg`: custom local reply message for SAML auth failures
+
+### Important Notes
+
+- `acs_url` and `metadata_url` must use the same scheme and host.
+- `metadata_url` is the SP metadata endpoint that the IdP imports.
+- `idp_metadata_url` or `idp_metadata_file` is used by Pixiu to learn the IdP signing key and SSO endpoint.
+- Pixiu removes client-supplied values for headers listed in `forward_attributes` before writing SAML-derived values.
+- HTTPS is strongly recommended.
+
+### Cookie and HTTPS Behavior
+
+SAML SP-initiated login usually depends on a request-tracking cookie surviving the cross-site POST back from the IdP to the ACS endpoint.
+
+- Under HTTPS, Pixiu uses `SameSite=None`, which allows the cookie to be sent on the cross-site ACS POST.
+- Under plain HTTP development, browsers typically reject the combination needed for that flow, so Pixiu falls back to the browser default cookie policy.
+- For local HTTP development, you may need `allow_idp_initiated: true` so the ACS flow can continue without relying on strict `InResponseTo` validation.
+
+In some local HTTP browser environments, the first login may not return cleanly to the original route because the request-tracking cookie is dropped on the ACS POST. In that case, the session may already have been created successfully. Revisit `/app` to verify the login result when testing the local sample.
+
+### Sample
+
+A runnable sample is maintained in `dubbo-go-pixiu-samples` under `dubbogo/simple/saml`.

--- a/content/en/overview/reference/pixiu/other/user/httpfilter/saml.md
+++ b/content/en/overview/reference/pixiu/other/user/httpfilter/saml.md
@@ -101,4 +101,4 @@ In some local HTTP browser environments, the first login may not return cleanly 
 
 ### Sample
 
-A runnable sample is maintained in `dubbo-go-pixiu-samples` under `dubbogo/simple/saml`.
+A runnable sample is maintained in `dubbo-go-pixiu-samples` under `auth/saml`.

--- a/content/zh-cn/overview/reference/pixiu/other/user/httpfilter/saml.md
+++ b/content/zh-cn/overview/reference/pixiu/other/user/httpfilter/saml.md
@@ -1,0 +1,105 @@
+---
+aliases:
+  - /zh/docs3-v2/dubbo-go-pixiu/user/httpfilter/saml/
+  - /zh-cn/docs3-v2/dubbo-go-pixiu/user/httpfilter/saml/
+  - /zh-cn/overview/reference/pixiu/other/user/httpfilter/saml/
+  - /zh-cn/overview/mannual/dubbo-go-pixiu/user/httpfilter/saml/
+description: SAML 介绍
+linkTitle: SAML 介绍
+title: SAML 介绍
+type: docs
+weight: 25
+---
+
+# SAML 认证过滤器 (dgp.filter.http.auth.saml)
+
+---
+
+## 中文
+
+### 概述
+
+`dgp.filter.http.auth.saml` 过滤器允许 Pixiu 作为一个 SAML Service Provider（SP，服务提供方）运行。
+
+启用后，Pixiu 可以：
+
+- 暴露 SP metadata 端点，供 IdP 注册使用
+- 将未认证的浏览器请求重定向到 IdP 登录页
+- 在 ACS 端点接收并处理 `SAMLResponse`
+- 在用户登录成功后创建 session cookie
+- 将选定的 SAML assertion 属性转发为上游 HTTP 请求头
+
+常见的 IdP 包括 Keycloak、Okta 和 Microsoft Entra ID。
+
+### 请求流程
+
+1. 浏览器访问受保护的 Pixiu 路径，例如 `/app`。
+2. Pixiu 检查当前请求是否携带有效的 SAML session cookie。
+3. 如果 session 不存在，Pixiu 会将浏览器重定向到 IdP 登录页。
+4. 用户完成登录后，IdP 会向 Pixiu 的 ACS 端点 POST 一个 `SAMLResponse`。
+5. Pixiu 校验 assertion，创建 session cookie，并将浏览器重定向回最初访问的路径。
+6. 之后的请求会继续转发到上游服务，同时将配置好的 SAML 属性映射到 HTTP 头中。
+
+### 最小配置
+
+```yaml
+http_filters:
+  - name: "dgp.filter.http.auth.saml"
+    config:
+      entity_id: "pixiu-saml-sp"
+      acs_url: "https://pixiu.example.com/saml/acs"
+      metadata_url: "https://pixiu.example.com/saml/metadata"
+      idp_metadata_url: "https://idp.example.com/app/metadata"
+      cert_file: "/etc/pixiu/saml/sp.crt"
+      key_file: "/etc/pixiu/saml/sp.key"
+      rules:
+        - match:
+            prefix: "/app"
+      forward_attributes:
+        - saml_attribute: "email"
+          header: "X-User-Email"
+        - saml_attribute: "displayName"
+          header: "X-User-Name"
+```
+
+如果不想通过 `idp_metadata_url` 拉取，也可以从本地文件加载 IdP metadata：
+
+```yaml
+idp_metadata_file: "/etc/pixiu/saml/idp-metadata.xml"
+```
+
+### 配置字段说明
+
+- `entity_id`：Pixiu 作为 SP 对外声明的 entity ID
+- `acs_url`：Assertion Consumer Service 端点地址，用于接收 `SAMLResponse`
+- `metadata_url`：Pixiu 的 SP metadata 地址，提供给 IdP 管理员导入配置
+- `idp_metadata_url`：Pixiu 拉取 IdP metadata 的 URL
+- `idp_metadata_file`：本地 IdP metadata 文件路径，可替代 `idp_metadata_url`
+- `cert_file`：SP 证书文件
+- `key_file`：SP 私钥文件
+- `rules`：需要启用 SAML 登录保护的路径前缀
+- `forward_attributes`：将 SAML assertion 属性映射到上游 HTTP 头
+- `allow_idp_initiated`：面向本地 HTTP 开发测试场景的兼容开关；当浏览器在跨站 ACS POST 时丢失请求跟踪 cookie 时，可通过该开关放宽校验
+- `err_msg`：SAML 认证失败时返回的本地错误消息
+
+### 重要说明
+
+- `acs_url` 和 `metadata_url` 必须使用相同的 scheme 和 host。
+- `metadata_url` 表示 SP metadata 地址，供 IdP 导入配置。
+- `idp_metadata_url` 或 `idp_metadata_file` 用于让 Pixiu 获取 IdP 的签名证书和 SSO 端点。
+- Pixiu 会先移除 `forward_attributes` 中配置的客户端自带请求头，再写入来自 SAML assertion 的值，以避免 header spoofing。
+- 强烈建议在生产环境使用 HTTPS。
+
+### Cookie 与 HTTPS 行为
+
+SAML 的 SP-initiated 登录流程通常依赖一个“请求跟踪 cookie”，以便在 IdP 向 ACS 发起跨站 POST 时，Pixiu 仍然能够将返回的 `SAMLResponse` 与先前发起的认证请求对应起来。
+
+- 在 HTTPS 场景下，Pixiu 会使用 `SameSite=None`，这样浏览器才会在跨站 ACS POST 时携带该 cookie。
+- 在纯 HTTP 开发环境下，浏览器通常会拒绝这组组合要求，因此 Pixiu 会退回到浏览器默认的 cookie 策略。
+- 因此，在本地 HTTP 开发环境中，你可能需要设置 `allow_idp_initiated: true`，使 ACS 流程在不依赖严格 `InResponseTo` 校验的情况下也能继续完成。
+
+在部分本地 HTTP 浏览器环境中，首次登录后浏览器可能不会正确返回原始业务路径，因为请求跟踪 cookie 在 ACS 跨站 POST 时被丢弃。此时本地登录 session 也可能已经创建成功。测试本地 sample 时，可在登录后重新访问 `/app` 进行确认。
+
+### 示例
+
+可运行示例位于 `dubbo-go-pixiu-samples` 仓库中的 `dubbogo/simple/saml`。

--- a/content/zh-cn/overview/reference/pixiu/other/user/httpfilter/saml.md
+++ b/content/zh-cn/overview/reference/pixiu/other/user/httpfilter/saml.md
@@ -102,4 +102,4 @@ SAML 的 SP-initiated 登录流程通常依赖一个“请求跟踪 cookie”，
 
 ### 示例
 
-可运行示例位于 `dubbo-go-pixiu-samples` 仓库中的 `dubbogo/simple/saml`。
+可运行示例位于 `dubbo-go-pixiu-samples` 仓库中的 `auth/saml`。


### PR DESCRIPTION
## What this PR does

This PR adds SAML filter documentation for the Pixiu website.

## Changes

- add English documentation for the SAML filter
- add Chinese documentation for the SAML filter
- describe the SAML login flow and key configuration fields
- add local development notes for HTTP testing
- explain the cookie behavior difference between HTTP and HTTPS

## Related

- follow-up for apache/dubbo-go-pixiu#893
- sample PR: apache/dubbo-go-pixiu-samples#125
