### PR TITLE
fix typo GITHUB to GitHub in navbar and footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,7 +16,7 @@
             <img src="https://img.alicdn.com/imgextra/i4/O1CN01buuadT274Lj33QZWQ_!!6000000007743-0-tps-1170-1477.jpg" alt="DingTalk QR Code">
           </div>
         </button>
-        <button class="contact-btn"><a href="https://github.com/apache/dubbo/">GITHUB</a></button>
+        <button class="contact-btn"><a href="https://github.com/apache/dubbo/">GitHub</a></button>
       </div>
     </div>
     <div class="footer-container-right">

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -87,7 +87,7 @@
       </ul>
 
       <a class="btn btn-dark ml-2 github-btn"
-        href="https://github.com/apache/dubbo/">GITHUB</a>
+        href="https://github.com/apache/dubbo/">GitHub</a>
     </div>
 
   </div>


### PR DESCRIPTION
Corrected the capitalization of "GitHub" in the navigation and footer to follow the official branding guidelines and improve consistency across the site.

local test:
<img width="3010" height="1366" alt="image" src="https://github.com/user-attachments/assets/69f429ea-9587-4066-8474-632c079a2fa6" />
