### PR TITLE
docs(golang): add static router config docs for tag and condition router

### DIFF
--- a/content/en/overview/mannual/golang-sdk/tutorial/traffic/condition_router.md
+++ b/content/en/overview/mannual/golang-sdk/tutorial/traffic/condition_router.md
@@ -118,7 +118,7 @@ Parameters:
 The static sample in `dubbo-go-samples` uses direct URLs only to keep the example minimal; it does not mean the API is limited to direct-connect scenarios.
 
 For the static example, please
-see: [Full Example Code](https://github.com/apache/dubbo-go-samples/tree/bdcb408a52b6cf3d4f70e5b6f2b0ab52a8f04f43/router/static_config/condition).
+see: [Full Example Code](https://github.com/apache/dubbo-go-samples/tree/main/router/static_config/condition).
 
 ### Priority and merge semantics
 

--- a/content/en/overview/mannual/golang-sdk/tutorial/traffic/condition_router.md
+++ b/content/en/overview/mannual/golang-sdk/tutorial/traffic/condition_router.md
@@ -64,7 +64,7 @@ ins, err := dubbo.NewInstance(
 rep, err := srv.Greet(context.Background(), &greet.GreetRequest{Name: "hello world"})
 ```
 
-> A configuration in Nacos is needed if you want to use condition router.
+> The example above uses dynamic configuration and requires a config in Nacos or another config center.
 
 Example config:
 
@@ -86,3 +86,43 @@ conditions:
 
 For the complete example, please
 see: [Full Example Code](https://github.com/apache/dubbo-go-samples/tree/main/router/condition).
+
+### Static configuration API
+
+Besides the dynamic approach above, condition router also supports injecting routing rules statically in code. Static configuration does not require a config center, and it can work with direct URLs or with instances discovered from a registry.
+
+The following example shows a service-scope static condition router:
+
+```go
+ins, err := dubbo.NewInstance(
+	dubbo.WithName(clientApplication),
+	dubbo.WithRouter(
+		router.WithScope("service"),
+		router.WithKey(greet.GreetServiceName),
+		router.WithPriority(100),
+		router.WithForce(true),
+		router.WithConditions([]string{
+			"method = Greet => port = 20000",
+		}),
+	),
+)
+```
+
+Parameters:
+
+- `router.WithScope("service")`: applies the rule at service scope.
+- `router.WithKey(greet.GreetServiceName)`: binds the rule to the target service key.
+- `router.WithConditions(...)`: declares the static condition expressions.
+- `router.WithForce(true)`: controls whether fallback is allowed when the rule does not match.
+
+The static sample in `dubbo-go-samples` uses direct URLs only to keep the example minimal; it does not mean the API is limited to direct-connect scenarios.
+
+For the static example, please
+see: [Full Example Code](https://github.com/apache/dubbo-go-samples/tree/bdcb408a52b6cf3d4f70e5b6f2b0ab52a8f04f43/router/static_config/condition).
+
+### Priority and merge semantics
+
+- Dynamically delivered routing rules override static configuration.
+- When `dubbo.WithRouter(...)` is called multiple times, append semantics apply and multiple static router entries are appended to the instance configuration.
+- When `router.WithConditions(...)` is set multiple times on the same static router entry, replace semantics apply and the later setting replaces the earlier one.
+- Repeatedly injecting the exact same static rule usually leads to the same effective routing result, but the implementation does not compare old and new content and short-circuit as a no-op.

--- a/content/en/overview/mannual/golang-sdk/tutorial/traffic/tag_router.md
+++ b/content/en/overview/mannual/golang-sdk/tutorial/traffic/tag_router.md
@@ -107,7 +107,7 @@ Parameters:
 The static sample in `dubbo-go-samples` uses direct URLs only to keep the example minimal; it does not mean the API is limited to direct-connect scenarios.
 
 For the static example, please
-see: [Full Example Code](https://github.com/apache/dubbo-go-samples/tree/bdcb408a52b6cf3d4f70e5b6f2b0ab52a8f04f43/router/static_config/tag).
+see: [Full Example Code](https://github.com/apache/dubbo-go-samples/tree/main/router/static_config/tag).
 
 ### Priority and merge semantics
 

--- a/content/en/overview/mannual/golang-sdk/tutorial/traffic/tag_router.md
+++ b/content/en/overview/mannual/golang-sdk/tutorial/traffic/tag_router.md
@@ -64,3 +64,54 @@ Parameters:
 
 For the complete example, please
 see: [Full Example Code](https://github.com/apache/dubbo-go-samples/tree/main/router/tag).
+
+### Static configuration API
+
+Besides the usage above, tag router also supports injecting routing rules statically in code. Static configuration does not require a config center, and it can work with direct URLs or with instances discovered from a registry.
+
+The following example shows an application-scope static tag router:
+
+```go
+ins, err := dubbo.NewInstance(
+	dubbo.WithName(clientApplication),
+	dubbo.WithRouter(
+		router.WithScope("application"),
+		router.WithKey(clientApplication),
+		router.WithPriority(100),
+		router.WithForce(false),
+		router.WithTags([]global.Tag{
+			{
+				Name:      "gray",
+				Addresses: []string{"127.0.0.1:20002"},
+			},
+		}),
+	),
+)
+```
+
+Request tag attachment:
+
+```go
+ctx := context.WithValue(context.Background(), constant.AttachmentKey, map[string]string{
+	constant.Tagkey: "gray",
+})
+```
+
+Parameters:
+
+- `router.WithScope("application")`: applies the rule at application scope.
+- `router.WithKey(clientApplication)`: binds the rule to the consumer application.
+- `router.WithTags(...)`: declares the static mapping from tag to address list.
+- `router.WithForce(...)`: controls whether fallback is allowed when no tagged provider matches.
+
+The static sample in `dubbo-go-samples` uses direct URLs only to keep the example minimal; it does not mean the API is limited to direct-connect scenarios.
+
+For the static example, please
+see: [Full Example Code](https://github.com/apache/dubbo-go-samples/tree/bdcb408a52b6cf3d4f70e5b6f2b0ab52a8f04f43/router/static_config/tag).
+
+### Priority and merge semantics
+
+- Dynamically delivered routing rules override static configuration.
+- When `dubbo.WithRouter(...)` is called multiple times, append semantics apply and multiple static router entries are appended to the instance configuration.
+- When `router.WithTags(...)` is set multiple times on the same static router entry, replace semantics apply and the later setting replaces the earlier one.
+- Repeatedly injecting the exact same static rule usually leads to the same effective routing result, but the implementation does not compare old and new content and short-circuit as a no-op.

--- a/content/zh-cn/overview/mannual/golang-sdk/tutorial/traffic/condition_router.md
+++ b/content/zh-cn/overview/mannual/golang-sdk/tutorial/traffic/condition_router.md
@@ -63,7 +63,7 @@ ins, err := dubbo.NewInstance(
 rep, err := srv.Greet(context.Background(), &greet.GreetRequest{Name: "hello world"})
 ```
 
-> 使用condition router必须在nacos等配置中心动态设置匹配规则。
+> 上述示例使用的是动态配置方式，需要在nacos等配置中心动态设置匹配规则。
 
 Nacos配置示例:
 
@@ -85,3 +85,42 @@ conditions:
 ```
 
 完整示例请见: [本示例完整代码](https://github.com/apache/dubbo-go-samples/tree/main/router/condition)。
+
+### 静态配置 API
+
+除上面的动态配置方式外，Condition router 也支持通过静态配置 API 在代码中注入路由规则。静态配置不要求配置中心参与，可以配合直连 URL 使用，也可以配合注册中心使用。
+
+下面是一个服务级静态 condition router 的示例：
+
+```go
+ins, err := dubbo.NewInstance(
+	dubbo.WithName(clientApplication),
+	dubbo.WithRouter(
+		router.WithScope("service"),
+		router.WithKey(greet.GreetServiceName),
+		router.WithPriority(100),
+		router.WithForce(true),
+		router.WithConditions([]string{
+			"method = Greet => port = 20000",
+		}),
+	),
+)
+```
+
+参数：
+
+- `router.WithScope("service")`: 按服务维度生效。
+- `router.WithKey(greet.GreetServiceName)`: 指定当前规则作用的服务键。
+- `router.WithConditions(...)`: 静态声明 condition router 的匹配表达式。
+- `router.WithForce(true)`: 控制规则命中失败时是否允许回退。
+
+`dubbo-go-samples` 中的静态示例使用直连 URL，只是为了最小化演示，不代表该 API 只能用于直连场景。
+
+静态配置示例请见: [本示例完整代码](https://github.com/apache/dubbo-go-samples/tree/bdcb408a52b6cf3d4f70e5b6f2b0ab52a8f04f43/router/static_config/condition)。
+
+### 规则优先级与合并语义
+
+- 动态配置的路由规则会覆盖静态配置。
+- 多次调用 `dubbo.WithRouter(...)` 时，采用 append 语义，多条静态路由会被追加到实例配置中。
+- 对同一条静态路由多次设置 `router.WithConditions(...)` 时，采用 replace 语义，后一次设置会替换前一次设置。
+- 重复注入完全相同的静态规则时，最终路由结果通常保持一致，但实现上不会先比较新旧内容并短路跳过。

--- a/content/zh-cn/overview/mannual/golang-sdk/tutorial/traffic/condition_router.md
+++ b/content/zh-cn/overview/mannual/golang-sdk/tutorial/traffic/condition_router.md
@@ -116,7 +116,7 @@ ins, err := dubbo.NewInstance(
 
 `dubbo-go-samples` 中的静态示例使用直连 URL，只是为了最小化演示，不代表该 API 只能用于直连场景。
 
-静态配置示例请见: [本示例完整代码](https://github.com/apache/dubbo-go-samples/tree/bdcb408a52b6cf3d4f70e5b6f2b0ab52a8f04f43/router/static_config/condition)。
+静态配置示例请见: [本示例完整代码](https://github.com/apache/dubbo-go-samples/tree/main/router/static_config/condition)。
 
 ### 规则优先级与合并语义
 

--- a/content/zh-cn/overview/mannual/golang-sdk/tutorial/traffic/tag_router.md
+++ b/content/zh-cn/overview/mannual/golang-sdk/tutorial/traffic/tag_router.md
@@ -103,7 +103,7 @@ ctx := context.WithValue(context.Background(), constant.AttachmentKey, map[strin
 
 `dubbo-go-samples` 中的静态示例使用直连 URL，只是为了最小化演示，不代表静态配置 API 只能用于直连场景。
 
-静态配置示例请见: [本示例完整代码](https://github.com/apache/dubbo-go-samples/tree/bdcb408a52b6cf3d4f70e5b6f2b0ab52a8f04f43/router/static_config/tag)。
+静态配置示例请见: [本示例完整代码](https://github.com/apache/dubbo-go-samples/tree/main/router/static_config/tag)。
 
 ### 规则优先级与合并语义
 

--- a/content/zh-cn/overview/mannual/golang-sdk/tutorial/traffic/tag_router.md
+++ b/content/zh-cn/overview/mannual/golang-sdk/tutorial/traffic/tag_router.md
@@ -61,3 +61,53 @@ resp, err := svc.Greet(ctx, &greet.GreetRequest{Name: name})
 > 未携带标签的流量只能打到未携带标签的服务，携带标签的流量则可以打到携带相应标签的服务以及不具有标签的服务（取决于是否配置force参数）。
 
 完整示例请见: [本示例完整代码](https://github.com/apache/dubbo-go-samples/tree/main/router/tag)。
+
+### 静态配置 API
+
+除上面的用法外，Tag router 也支持通过静态配置 API 在代码中注入路由规则。静态配置不要求配置中心参与，可以配合直连 URL 使用，也可以配合注册中心使用。
+
+下面是一个应用级静态 tag router 的示例：
+
+```go
+ins, err := dubbo.NewInstance(
+	dubbo.WithName(clientApplication),
+	dubbo.WithRouter(
+		router.WithScope("application"),
+		router.WithKey(clientApplication),
+		router.WithPriority(100),
+		router.WithForce(false),
+		router.WithTags([]global.Tag{
+			{
+				Name:      "gray",
+				Addresses: []string{"127.0.0.1:20002"},
+			},
+		}),
+	),
+)
+```
+
+携带请求 tag：
+
+```go
+ctx := context.WithValue(context.Background(), constant.AttachmentKey, map[string]string{
+	constant.Tagkey: "gray",
+})
+```
+
+参数：
+
+- `router.WithScope("application")`: 按应用维度生效。
+- `router.WithKey(clientApplication)`: 指定当前路由规则绑定的 consumer application。
+- `router.WithTags(...)`: 静态声明 tag 到地址列表的映射关系。
+- `router.WithForce(...)`: 控制 tag 不匹配时是否允许回退。
+
+`dubbo-go-samples` 中的静态示例使用直连 URL，只是为了最小化演示，不代表静态配置 API 只能用于直连场景。
+
+静态配置示例请见: [本示例完整代码](https://github.com/apache/dubbo-go-samples/tree/bdcb408a52b6cf3d4f70e5b6f2b0ab52a8f04f43/router/static_config/tag)。
+
+### 规则优先级与合并语义
+
+- 动态配置的路由规则会覆盖静态配置。
+- 多次调用 `dubbo.WithRouter(...)` 时，采用 append 语义，多条静态路由会被追加到实例配置中。
+- 对同一条静态路由多次设置 `router.WithTags(...)` 时，采用 replace 语义，后一次设置会替换前一次设置。
+- 重复注入完全相同的静态规则时，最终路由结果通常保持一致，但实现上不会先比较新旧内容并短路跳过。


### PR DESCRIPTION
New static config docs for router.

the static sample links in this PR currently point to a fixed commit in
  `apache/dubbo-go-samples`, for example:

  ```
  https://github.com/apache/dubbo-go-samples/tree/bdcb408a52b6cf3d4f70e5b6f2b0ab52a8f04f43/router/static_config/condition
  
  https://github.com/apache/dubbo-go-samples/tree/bdcb408a52b6cf3d4f70e5b6f2b0ab52a8f04f43/router/static_config/tag
```

  because the corresponding static router samples have not been merged into `apache/
  dubbo-go-samples` yet. Once the samples PR is merged, I will follow up and switch
  these links to the normal branch-based paths.