### PR TITLE
fix: Add required ASF policy links to footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -35,13 +35,20 @@
 
   <div style="width:85.125rem;height:0px;border: 1px solid #DDDEE4;margin-bottom: 32px;"></div>
   <div class="footer-registration">
-    © 2024 The Apache Software Foundation. Apache Dubbo, Dubbo, Apache, the Apache feather logo, and the Apache Dubbo
+    © 2026 The Apache Software Foundation. Apache Dubbo, Dubbo, Apache, the Apache feather logo, and the Apache Dubbo
     project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States
     and other countries. {{ T "footer_bottom_tip" }}
   </div>
+  <div class="footer-links">
+    <a href="https://www.apache.org/">Foundation</a> |
+    <a href="https://www.apache.org/licenses/">License</a> |
+    <a href="https://www.apache.org/events/current-event.html">Events</a> |
+    <a href="https://www.apache.org/security/">Security</a> |
+    <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
+    <a href="https://www.apache.org/foundation/thanks.html">Thanks</a> |
+    <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a>
+  </div>
 </footer>
-
-
 
 <style>
   footer {
@@ -170,6 +177,18 @@
     text-align: center;
     color: #A3A6B3;
     margin-bottom: 32px;
+  }
+
+  .footer-links {
+    font-size: 14px;
+    line-height: 24px;
+    text-align: center;
+    color: #A3A6B3;
+    margin-bottom: 32px;
+  }
+  .footer-links a {
+    color: #818598;
+    text-decoration: none;
   }
 
   .qr-container { 


### PR DESCRIPTION
fix: Add required ASF policy links to footer

The Dubbo website is missing several links required by ASF website
policy (https://whimsy.apache.org/site/):

- Foundation link (apache.org)
- License
- Events
- Security (the existing /en/overview/notices/ page is not recognized)
- Sponsorship
- Thanks
- Privacy

This adds the standard ASF policy links row to the footer and updates
the copyright year from 2024 to 2026.

See: https://www.apache.org/foundation/marks/pmcs
Checker: https://whimsy.apache.org/site/