### PR TITLE
docs: add Go static script router config

### DIFF
--- a/content/en/overview/mannual/golang-sdk/tutorial/traffic/script_router.md
+++ b/content/en/overview/mannual/golang-sdk/tutorial/traffic/script_router.md
@@ -43,5 +43,40 @@ script: |
   })(invokers, invocation, context);
 ```
 
+> The `Data Id` of the dynamic config must be `{provider_application}.script-router`.
+
+### Static configuration
+
+Script router also supports local static router configuration. Static configuration is useful when you want script routing without a config center, or when you need a bootstrap rule before dynamic configuration is available.
+
+The following example adds an application-scope static script rule when creating a reference:
+
+```go
+conn, err := cli.NewService(&svc,
+	client.WithRouter(&global.RouterConfig{
+		Scope:      constant.RouterScopeApplication,
+		Key:        "script-server",
+		ScriptType: "javascript",
+		Script: `
+(function(invokers, invocation, context) {
+  if (!invokers || invokers.length === 0) return [];
+  return invokers.filter(function(invoker) {
+    var url = invoker.GetURL();
+    return url && url.Port === "20000";
+  });
+})(invokers, invocation, context);`,
+	}),
+)
+```
+
+`Key` must be the target provider application name. Static script rules are stored by `{provider_application}.script-router`, so multiple static entries can coexist when their provider application names are different.
+
+### Priority and merge semantics
+
+- Dynamically delivered script rules override static configuration for the same provider application.
+- Script router only supports application-scope static rules.
+- A static rule with an empty `key`, empty `type`, empty `script`, `enabled: false`, an unsupported script type, or an invalid script is ignored.
+- If no dynamic script rule is active for the provider application, Dubbo uses the matching static script rule.
+
 For the complete example, please
 see: [Full Example Code](https://github.com/apache/dubbo-go-samples/tree/main/router/script).

--- a/content/zh-cn/overview/mannual/golang-sdk/tutorial/traffic/script_router.md
+++ b/content/zh-cn/overview/mannual/golang-sdk/tutorial/traffic/script_router.md
@@ -46,4 +46,39 @@ script: |
 | type   | script的类型，目前仅可使用js |
 | script | script实际内容         |
 
+> 动态配置的 `Data Id` 必须是 `{provider_application}.script-router`。
+
+### 静态配置
+
+Script router 同时支持本地静态路由配置。静态配置适用于不使用配置中心的场景，或在动态配置下发前提供启动阶段的默认规则。
+
+下面的示例在创建引用时添加一个应用粒度的静态脚本路由规则：
+
+```go
+conn, err := cli.NewService(&svc,
+	client.WithRouter(&global.RouterConfig{
+		Scope:      constant.RouterScopeApplication,
+		Key:        "script-server",
+		ScriptType: "javascript",
+		Script: `
+(function(invokers, invocation, context) {
+  if (!invokers || invokers.length === 0) return [];
+  return invokers.filter(function(invoker) {
+    var url = invoker.GetURL();
+    return url && url.Port === "20000";
+  });
+})(invokers, invocation, context);`,
+	}),
+)
+```
+
+`Key` 必须是目标 provider application 名称。静态脚本规则会按 `{provider_application}.script-router` 存储，因此不同 provider application 的多条静态规则可以同时存在。
+
+### 优先级与合并语义
+
+- 配置中心下发的动态脚本规则优先于同一 provider application 的静态配置。
+- Script router 的静态配置仅支持应用粒度规则。
+- 如果静态规则的 `key`、`type`、`script` 为空，`enabled: false`，脚本类型不支持，或脚本内容无法编译，该规则会被忽略。
+- 如果当前 provider application 没有生效的动态脚本规则，Dubbo 会使用匹配的静态脚本规则。
+
 完整示例请见: [本示例完整代码](https://github.com/apache/dubbo-go-samples/tree/main/router/script)。


### PR DESCRIPTION
## What is changed

- Document the Go script router dynamic config Data Id.
- Add local static script router configuration examples for English and Chinese docs.
- Clarify provider-application keying and dynamic/static priority semantics.

Follow-up for apache/dubbo-go#3419.

## Checklist

- [x] English documentation updated
- [x] Chinese documentation updated
- [x] `git diff --check` passed