### PR TITLE
docs(golang-sdk): 完善条件路由文档的运行流程与验证方式

### DIFF
--- a/content/en/overview/mannual/golang-sdk/tutorial/traffic/condition_router.md
+++ b/content/en/overview/mannual/golang-sdk/tutorial/traffic/condition_router.md
@@ -71,23 +71,52 @@ rep, err := srv.Greet(context.Background(), &greet.GreetRequest{Name: "hello wor
 
 > The example above uses dynamic configuration and requires a config in Nacos or another config center.
 
+Run the sample (the two servers belong to the same application `condition-server`, and the client calls the `Greet` method every 5 seconds):
+
+```shell
+$ go run ./go-server/cmd/server.go              # port 20001
+$ go run ./go-node2-server/cmd/server_node2.go  # port 20000
+$ go run ./go-client/cmd/client.go
+```
+
 Example config:
 
-> The `Data Id` of config must be `{application_name}.{router_type}` (e.g. condition-server.condition-router).
+> The `Data Id` of config must be `{application_name}.{router_type}` (e.g. `condition-server.condition-router`, where the application name is the **server-side** application name).
+> Group uses the default `DEFAULT_GROUP`, and the config format is `YAML`.
 
 ```yaml
-configVersion: v3.1
+configVersion: V3.3.2
 scope: "application"
 key: "condition-server"
 priority: 1
 force: true
-enabled: false
+enabled: true
 conditions:
   - from:
       match: "application = condition-client"
     to:
-      - match: "port = 20000"
+      - match: "port = 20001"
 ```
+
+Key fields:
+
+- `enabled`: whether this rule is enabled; it must be set to `true` when published.
+- `force`: whether the rule stays effective when it filters out every provider. `true` means no fallback and the call fails directly; `false` means falling back to the full address list.
+
+Expected results:
+
+- Before the rule is published, the client calls normally and responses come from the instances on port 20000 or 20001.
+- After the rule is published, running clients pick it up without restart, and responses only come from the instance on port 20001:
+
+  ```
+  receive: hello world from: 20001
+  ```
+
+- After the rule is deleted, the client calls become unrestricted again.
+
+> When `force: true` and the rule filters out every provider, the call fails directly and the client log contains
+> `route an empty set in condition-route`, which means the rule is effective but matches no instance.
+> In that case, check whether the `to.match` condition is consistent with the actual instance parameters (such as the port).
 
 For the complete example, please
 see: [Full Example Code](https://github.com/apache/dubbo-go-samples/tree/main/router/condition).

--- a/content/zh-cn/overview/mannual/golang-sdk/tutorial/traffic/condition_router.md
+++ b/content/zh-cn/overview/mannual/golang-sdk/tutorial/traffic/condition_router.md
@@ -70,24 +70,53 @@ rep, err := srv.Greet(context.Background(), &greet.GreetRequest{Name: "hello wor
 
 > 上述示例使用的是动态配置方式，需要在nacos等配置中心动态设置匹配规则。
 
+运行示例（两个服务端同属应用`condition-server`，客户端每 5 秒调用一次`Greet`方法）:
+
+```shell
+$ go run ./go-server/cmd/server.go              # 20001端口
+$ go run ./go-node2-server/cmd/server_node2.go  # 20000端口
+$ go run ./go-client/cmd/client.go
+```
+
 Nacos配置示例:
 
 > 配置的`Data ID`名字必须为: `{application_name}.{router_type}`。
-> 例如: `condition-server.condition-router`。
+> 例如: `condition-server.condition-router`（这里的应用名是**服务端**的应用名）。
+> Group 使用默认的`DEFAULT_GROUP`，配置格式选择`YAML`。
 
 ```yaml
-configVersion: v3.1
+configVersion: V3.3.2
 scope: "application"
 key: "condition-server"
 priority: 1
 force: true
-enabled: false
+enabled: true
 conditions:
   - from:
       match: "application = condition-client"
     to:
-      - match: "port = 20000"
+      - match: "port = 20001"
 ```
+
+关键字段说明:
+
+- `enabled`: 是否启用本条规则，下发时需要设置为`true`。
+- `force`: 路由结果为空集时是否强制生效。`true`表示不回退、直接调用失败；`false`表示回退到全量地址列表。
+
+预期结果:
+
+- 未下发规则时，客户端可以正常调用，响应来自 20000 或 20001 端口的实例。
+- 规则下发后，运行中的客户端无需重启即可生效，响应只会来自 20001 端口的实例:
+
+  ```
+  receive: hello world from: 20001
+  ```
+
+- 删除规则后，客户端调用恢复为不受限状态。
+
+> 当`force: true`且规则过滤后没有可用 provider 时，调用会直接失败，客户端日志中可以看到
+> `route an empty set in condition-route`字样，说明规则已生效但未匹配到任何实例，
+> 此时应检查`to.match`条件与实例的实际参数（如端口）是否一致。
 
 完整示例请见: [本示例完整代码](https://github.com/apache/dubbo-go-samples/tree/main/router/condition)。
 


### PR DESCRIPTION
apache/dubbo-go#3598 任务 14。@Alanxtl

## 主要改动

- 补充动态 condition router 的完整运行命令（两个 provider 端口与代码实际一致：`server.go`=20001、`server_node2.go`=20000）
- 补充 Nacos 配置项说明：Data ID 使用服务端应用名、Group 为 `DEFAULT_GROUP`、格式 YAML
- 修正规则示例：
  - `configVersion` 由 v3.1 更新为 V3.3.2（与 sample 对齐）
  - `enabled: false` 改为 `true`（原示例照抄不会生效）
  - `to.match` 端口与 sample 对齐（20001）
- 补充 `enabled` / `force` 字段说明
- 补充路由生效前后的预期输出，以及 `force: true` 时空集报错（`route an empty set`）的排查提示

## 验证

运行流程和预期输出均在本地 Nacos 2.5.2 + dubbo-go v3.3.2 环境实测（规则下发后运行中的客户端无需重启即生效，删除后恢复）。

## 关联示例

- https://github.com/apache/dubbo-go-samples/tree/main/router/condition
- https://github.com/apache/dubbo-go-samples/tree/main/router/static_config/condition