### PR TITLE
docs: improve Nacos registry guide

### DIFF
--- a/content/en/overview/mannual/golang-sdk/tutorial/service-discovery/nacos.md
+++ b/content/en/overview/mannual/golang-sdk/tutorial/service-discovery/nacos.md
@@ -13,37 +13,131 @@ This example shows dubbo-go's service discovery feature with Nacos as the regist
 <a href="https://github.com/apache/dubbo-go-samples/tree/main/registry/nacos" target="_blank">complete example source code</a>
 in dubbo-go-samples.
 
-## Usage
+## How to Start
 
-Specify the registry address in the following way:
+### Start the Nacos Server
+
+Follow this instruction to [install and start the Nacos server](../../../../reference/integrations/nacos.md).
+
+## Server Registration Configuration
+
+### API Configuration
 
 ```go
 ins, _ := dubbo.NewInstance(
-	dubbo.WithName("dubbo_registry_nacos_server"),
-	dubbo.WithRegistry(
-		registry.WithNacos(),
-		registry.WithAddress("127.0.0.1:8848"),
-	),
-	dubbo.WithProtocol(
-		protocol.WithTriple(),
-		protocol.WithPort(20000),
-	),
-)
-
-srv, err := ins.NewServer()
+		dubbo.WithName("dubbo_registry_nacos_server"),
+		dubbo.WithRegistry(
+			registry.WithNacos(),
+			registry.WithAddress(nacosAddr),
+		),
+		dubbo.WithProtocol(
+			protocol.WithTriple(),
+			protocol.WithPort(20000),
+		),
+	)
 ```
 
-## How to run
+The meaning of each configuration item is as follows:
 
-### Start Nacos server
-Follow this instruction to [install and start Nacos server](/en/overview/reference/integrations/nacos/).
+- `dubbo.WithName()` sets the application name. After the service is registered, `dubbo_registry_nacos_server` generates the corresponding application node in Nacos. (This is the example name)
+- `dubbo.WithRegistry()` adds the registry configuration.
+    - `registry.WithNacos()` specifies Nacos as the registry type.
+	- `registry.WithAddress()` sets the Nacos address.
+- `dubbo.WithProtocol()` adds the protocol configuration for the service provider.
+  - `protocol.WithTriple()` specifies the Triple protocol to expose the service.
+  - `protocol.WithPort()` sets the protocol listening port. The example uses `20000`.
 
-### Run server
+After the service is successfully registered, you can see the service address under the
+`/services/dubbo_registry_nacos_server` node in Nacos.
+
+### YAML Configuration
+
+If you pass the configuration through a configuration file instead of the API, please refer to the following YAML configuration.
+```yaml
+dubbo:
+  registries:
+    demoNacos:
+      protocol: nacos
+      timeout: 10s
+      address: 127.0.0.1:8848
+  protocols:
+    tripleProtocol:
+      name: tri
+      port: 20000
+  provider:
+    services:
+      GreetTripleServer:
+        interface: greet.GreetService
+```
+
+## Client Service Discovery Configuration
+
+### API Configuration
+
+```go
+ins, _ := dubbo.NewInstance(
+		dubbo.WithName("dubbo_registry_nacos_client"),
+		dubbo.WithRegistry(
+			registry.WithNacos(),
+			registry.WithAddress("127.0.0.1:8848"),
+		),
+	)
+```
+There is no need to use `dubbo.WithProtocol()` to configure the protocol here.
+
+### YAML Configuration
+
+```yaml
+dubbo:
+  registries:
+    demoNacos:
+      protocol: nacos
+      timeout: 3s
+      address: 127.0.0.1:8848
+  consumer:
+    references:
+      GreetServiceImpl:
+        protocol: tri
+        interface: greet.GreetService
+        registry: demoNacos
+        retries: 3
+        timeout: 3000
+
+```
+
+## How to Run
+
+Before running the example, make sure Nacos is started. You can follow [install and start the Nacos server](../../../../reference/integrations/nacos.md) to start it, or choose to start it using a Docker image:
+
 ```shell
-$ go run ./go-server/cmd/server.go
+docker run -d --name dubbo-go-nacos -e MODE=standalone -p 8848:8848 -p 9848:9848 nacos/nacos-server:v2.3.2
 ```
 
-Test if the RPC server works as expected:
+The JVM memory size of Nacos can be configured as needed, for example by limiting its heap memory with `-e JVM_XMS=256m -e JVM_XMX=256m`.
+
+```shell
+docker ps --filter name=dubbo-go-nacos
+```
+
+You should see that the Nacos container is running.
+
+Then download the example repository and enter the Nacos example directory:
+
+```shell
+git clone https://github.com/apache/dubbo-go-samples.git
+cd dubbo-go-samples/registry/nacos
+```
+
+### Start the Server
+
+Run in the first terminal:
+
+```shell
+go run ./go-server/cmd/server.go
+```
+
+The service provider listens on port `20000`. Open another terminal and confirm that the service is available with an HTTP request:
+
 ```shell
 $ curl \
     --header "Content-Type: application/json" \
@@ -51,10 +145,40 @@ $ curl \
     http://localhost:20000/greet.GreetService/Greet
 ```
 
-Open `https://localhost:8848/nacos/` with a browser, check if the URL address is successfully registered into Nacos.
+Expected response:
 
-### Run client
+```json
+{"greeting":"Dubbo"}
+```
+
+#### View the Registered Data
+
+**Method 1: Through the Nacos console**
+
+Open `http://localhost:8848/nacos/` in a browser, go to "Service Management → Service List", and check whether the `dubbo_registry_nacos_server` service exists. The table also shows the IP, port, ephemeral instances, weight, health status, metadata, and other data.
+
+**Method 2: Through the Nacos OpenAPI**
+
+```shell
+curl -X GET 'http://127.0.0.1:8848/nacos/v1/ns/instance/list?serviceName=dubbo_registry_nacos_server&groupName=DEFAULT_GROUP'
+```
+
+In the expected output, the hosts list should not be empty, and healthy should be true.
+
+
+
+### Run the Client
+
+Keep the server running, open a second terminal, and run:
+
 ```shell
 $ go run ./go-client/cmd/client.go
-hello world
 ```
+
+After execution, the terminal outputs multiple lines of service discovery and invocation logs, including the following response:
+
+```text
+Greet response: greeting:"hello world"
+```
+
+This shows that the client has found the service provider through Nacos and completed the invocation.

--- a/content/zh-cn/overview/mannual/golang-sdk/tutorial/service-discovery/nacos.md
+++ b/content/zh-cn/overview/mannual/golang-sdk/tutorial/service-discovery/nacos.md
@@ -13,37 +13,130 @@ weight: 10
 <a href="https://github.com/apache/dubbo-go-samples/tree/main/registry/nacos" target="_blank">dubbo-go-samples/registry/nacos</a>
 查看完整示例源码。
 
-## 使用方式
+## 如何启动
 
-通过以下方式指定注册中心地址：
+### 启动 Nacos 服务端
+遵循这个步骤以[安装并启动Nacos服务端](../../../../reference/integrations/nacos.md)。
+
+## 服务端注册配置说明
+
+### API 配置方式
 
 ```go
 ins, _ := dubbo.NewInstance(
-	dubbo.WithName("dubbo_registry_nacos_server"),
-	dubbo.WithRegistry(
-		registry.WithNacos(),
-		registry.WithAddress("127.0.0.1:8848"),
-	),
-	dubbo.WithProtocol(
-		protocol.WithTriple(),
-		protocol.WithPort(20000),
-	),
-)
-
-srv, err := ins.NewServer()
+		dubbo.WithName("dubbo_registry_nacos_server"),
+		dubbo.WithRegistry(
+			registry.WithNacos(),
+			registry.WithAddress(nacosAddr),
+		),
+		dubbo.WithProtocol(
+			protocol.WithTriple(),
+			protocol.WithPort(20000),
+		),
+	)
 ```
 
-## How to run
+各配置项的作用如下：
 
-### Start Nacos server
-Follow this instruction to [install and start Nacos server](/zh-cn/overview/reference/integrations/nacos/).
+- `dubbo.WithName()` 设置应用名。
+    `dubbo_registry_nacos_server` 服务注册后会在 Nacos 中生成对应的应用节点。（此为示例名称）
+- `dubbo.WithRegistry()` 添加注册中心配置。
+    - `registry.WithNacos()` 指定注册中心类型为 Nacos 。
+	- `registry.WithAddress()` 设置 Nacos 地址。
+- `dubbo.WithProtocol()` 添加服务提供者的协议配置。
+  - `protocol.WithTriple()` 指定使用 Triple 协议对外提供服务。
+  - `protocol.WithPort()` 设置协议监听端口，示例使用 `20000`。
 
-### Run server
+服务注册成功后，可以在 Nacos 的
+`/services/dubbo_registry_nacos_server` 节点下看到服务地址。
+
+### YAML 配置方式
+
+```yaml
+dubbo:
+  registries:
+    demoNacos:
+      protocol: nacos
+      timeout: 10s
+      address: 127.0.0.1:8848
+  protocols:
+    tripleProtocol:
+      name: tri
+      port: 20000
+  provider:
+    services:
+      GreetTripleServer:
+        interface: greet.GreetService
+```
+
+## 客户端发现服务配置说明
+
+### API 配置方式
+
+```go
+ins, _ := dubbo.NewInstance(
+		dubbo.WithName("dubbo_registry_nacos_client"),
+		dubbo.WithRegistry(
+			registry.WithNacos(),
+			registry.WithAddress("127.0.0.1:8848"),
+		),
+	)
+```
+这里不需要使用`dubbo.WithProtocol()`配置协议相关内容。
+
+### YAML 配置方式
+
+```yaml
+dubbo:
+  registries:
+    demoNacos:
+      protocol: nacos
+      timeout: 3s
+      address: 127.0.0.1:8848
+  consumer:
+    references:
+      GreetServiceImpl:
+        protocol: tri
+        interface: greet.GreetService
+        registry: demoNacos
+        retries: 3
+        timeout: 3000
+
+```
+
+## 如何运行
+
+在运行示例之前，请确保 Nacos 已启动。你可以参考 [安装并启动 Nacos 服务端](../../../../reference/integrations/nacos.md) 完成启动，又或者可以选择使用 Docker 镜像启动：
+
 ```shell
-$ go run ./go-server/cmd/server.go
+docker run -d --name dubbo-go-nacos -e MODE=standalone -p 8848:8848 -p 9848:9848 nacos/nacos-server:v2.3.2
 ```
 
-test rpc server work as expected:
+Nacos 的 JVM 内存大小可按需配置，例如通过 `-e JVM_XMS=256m -e JVM_XMX=256m` 限制其堆内存。
+
+```shell
+docker ps --filter name=dubbo-go-nacos
+```
+
+预期可以显示 Nacos 正在运行
+
+随后先下载示例仓库并进入 Nacos 示例目录：
+
+```shell
+git clone https://github.com/apache/dubbo-go-samples.git
+cd dubbo-go-samples/registry/nacos
+```
+
+### 启动服务端
+
+在第一个终端运行：
+
+```shell
+go run ./go-server/cmd/server.go
+```
+
+服务提供者会监听 `20000` 端口。新开一个终端，通过 HTTP 请求确认服务可用：
+
 ```shell
 $ curl \
     --header "Content-Type: application/json" \
@@ -51,10 +144,41 @@ $ curl \
     http://localhost:20000/greet.GreetService/Greet
 ```
 
-Open `https://localhost:8848/nacos/` with browser, check url address successfully registered into Nacos.
+预期返回：
 
-### Run client
+```json
+{"greeting":"Dubbo"}
+```
+
+#### 查看注册数据
+
+**方式一：通过 Nacos 控制台**
+
+用浏览器打开 `http://localhost:8848/nacos/`，进入“服务管理 → 服务列表”，查看是否存在 `dubbo_registry_nacos_server` 服务。表内还可查看IP、端口、临时实例、权重、健康状态、元数据等相关数据。
+
+**方式二：通过 Nacos OpenAPI**
+
+```shell
+curl -X GET 'http://127.0.0.1:8848/nacos/v1/ns/instance/list?serviceName=dubbo_registry_nacos_server&groupName=DEFAULT_GROUP'
+```
+
+预期输出中 hosts 列表不为空，且 healthy 为 true。
+
+
+
+### 运行客户端
+
+保证服务端持续运行，新开第二个终端运行指令
+
 ```shell
 $ go run ./go-client/cmd/client.go
-hello world
 ```
+
+命令执行后，终端会输出多行服务发现和调用日志，其中包含以下响应：
+
+```text
+Greet response: greeting:"hello world"
+```
+
+这说明客户端已经通过 Nacos 找到服务提供者并完成调用。
+

--- a/content/zh-cn/overview/mannual/golang-sdk/tutorial/service-discovery/nacos.md
+++ b/content/zh-cn/overview/mannual/golang-sdk/tutorial/service-discovery/nacos.md
@@ -52,6 +52,7 @@ ins, _ := dubbo.NewInstance(
 
 ### YAML 配置方式
 
+如果使用配置文件方式传入配置，而不是 API 的方式，请参考以下 YAML 配置。
 ```yaml
 dubbo:
   registries:


### PR DESCRIPTION
## 修改内容
- 将 Nacos 注册中心文档统一为中文
- 补充 Nacos 本地启动方式（Docker）
- 补充 provider 注册配置说明
- 补充 consumer 发现服务配置说明
- 补充运行 server/client 的完整命令
- 补充注册成功后的验证方式

## 关联任务

https://github.com/apache/dubbo-go/issues/3598#6-完善-nacos-注册中心文档

## 验证
- 对照 `dubbo-go-samples/registry/nacos` 校对示例代码、命令、服务节点和输出
- 本地实测：Docker 启动 Nacos 后，curl 返回 `{"greeting":"Dubbo"}`，客户端输出 `Greet response: greeting:"hello world"`

@Alanxtl